### PR TITLE
feat: add prefer-satisfies rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The rules are organized into the following categories:
 | **General** | |
 | [`no-silent-catch`](./src/rules/no-silent-catch.md) | disallow silently swallowing errors in `.catch()` or `try/catch` |
 | [`prefer-node-style-text`](./src/rules/prefer-node-style-text.ts) | prefer Node.js `styleText()` over raw ANSI escape codes |
+| [`prefer-satisfies`](./src/rules/prefer-satisfies.md) | prefer `satisfies` over a widening type annotation on object literals |
 | **AI Deslop** | |
 | [`ai-deslop-adverbs`](./src/prompt/rules/deslop-adverbs.ts) | remove unnecessary adverbs that add no meaning (e.g. "significantly", "fundamentally") |
 | [`ai-deslop-autolink`](./src/prompt/rules/deslop-autolink.ts) | auto-link first mention of known tech terms to their canonical URLs |

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import nuxtPreferNavigateToOverRouterPushReplace from './rules/nuxt-prefer-navig
 import nuxtPreferNuxtLinkOverRouterLink from './rules/nuxt-prefer-nuxt-link-over-router-link'
 import nuxtUiPreferShorthandCss from './rules/nuxt-ui-prefer-shorthand-css'
 import preferNodeStyleText from './rules/prefer-node-style-text'
+import preferSatisfies from './rules/prefer-satisfies'
 import vueNoAsyncLifecycleHook from './rules/vue-no-async-lifecycle-hook'
 import vueNoFauxComposables from './rules/vue-no-faux-composables'
 import vueNoNestedReactivity from './rules/vue-no-nested-reactivity'
@@ -120,6 +121,7 @@ const rules = defineRules({
   'nuxt-ui-prefer-shorthand-css': nuxtUiPreferShorthandCss,
   'pnpm-require-trust-policy': pnpmRequireTrustPolicy,
   'prefer-node-style-text': preferNodeStyleText,
+  'prefer-satisfies': preferSatisfies,
   'prompt-ambiguous-quantifier': promptAmbiguousQuantifier,
   'prompt-duplicate-heading': promptDuplicateHeading,
   'prompt-empty-section': promptEmptySection,
@@ -338,6 +340,7 @@ plugin.configs!.nuxt = [
       'harlanzw/nuxt-prefer-nuxt-link-over-router-link': 'warn',
       'harlanzw/nuxt-ui-prefer-shorthand-css': 'warn',
       'harlanzw/no-silent-catch': 'error',
+      'harlanzw/prefer-satisfies': 'warn',
     },
   },
 ]
@@ -363,6 +366,7 @@ plugin.configs!.vue = [
       'harlanzw/vue-prefer-define-emits-object-syntax': 'warn',
       'harlanzw/vue-require-composable-prefix': 'warn',
       'harlanzw/no-silent-catch': 'error',
+      'harlanzw/prefer-satisfies': 'warn',
     },
   },
   {

--- a/src/rules/prefer-satisfies.md
+++ b/src/rules/prefer-satisfies.md
@@ -1,0 +1,95 @@
+# prefer-satisfies
+
+Prefer `satisfies` over a widening type annotation on object literals.
+
+## Rule Details
+
+A `Record<string, V>` annotation tells TypeScript the object may hold any string key. The compiler then forgets which keys the literal actually declared:
+
+```ts
+const handlers: Record<string, Handler> = {
+  start: startHandler,
+}
+
+handlers.strat        // Handler. Compiles. undefined at runtime.
+keyof typeof handlers // string
+```
+
+`satisfies` checks the same constraint but keeps the literal type:
+
+```ts
+const handlers = {
+  start: startHandler,
+} satisfies Record<string, Handler>
+
+handlers.strat        // Property 'strat' does not exist.
+keyof typeof handlers // 'start'
+```
+
+You keep key autocomplete, exhaustive switches over `keyof typeof`, and a correct `Object.keys` result. Assignability and excess property checks still run, and inline arrow parameters still get contextual types.
+
+The rule reports a suggestion, not an autofix. Narrowing the type can surface real errors at other call sites, so each rewrite needs a look.
+
+## When the rule fires
+
+The annotation must erase a known key set, and the object must be safe to freeze:
+
+- the declaration is `const`
+- the annotation is `Record<string, V>`, `Record<number, V>`, `{ [key: string]: V }`, or one of those wrapped in `Readonly` or `Partial`
+- the value type `V` is not `any` or `unknown`
+- the initialiser is a non-empty object literal with no spread elements
+- the variable is never written to afterwards
+
+## Examples
+
+Incorrect:
+
+```ts
+const XML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+}
+
+const products: Record<number, Product> = {
+  1: widget,
+}
+
+const TITLES: Readonly<Record<string, string>> = {
+  seo: 'SEO',
+}
+```
+
+Correct:
+
+```ts
+const XML_ENTITIES = {
+  amp: '&',
+  lt: '<',
+} satisfies Record<string, string>
+```
+
+## When Not To Use It
+
+The rule already skips the cases below, but they explain why it stays narrow.
+
+A finite key union is not widening. The annotation forces you to cover every member, which `satisfies` cannot do:
+
+```ts
+const labels: Record<Status, string> = {
+  idle: 'Idle',
+  busy: 'Busy',
+}
+```
+
+A mutable map needs the open key type, because `satisfies` would reject any new key:
+
+```ts
+const counts: Record<string, number> = { total: 0 }
+counts[key] = 1
+```
+
+A bag of `unknown` or `any` values carries no evidence worth preserving:
+
+```ts
+const payload: Record<string, unknown> = { id: 1 }
+```

--- a/src/rules/prefer-satisfies.test.ts
+++ b/src/rules/prefer-satisfies.test.ts
@@ -1,0 +1,210 @@
+import type { Linter } from 'eslint'
+import { unindent as $ } from 'eslint-vitest-rule-tester'
+import { run } from './_test'
+import rule, { RULE_NAME } from './prefer-satisfies'
+
+/** Applies a report's single suggestion to `code` so the rewrite can be asserted. */
+function applySuggestion(code: string, message: Linter.LintMessage): string {
+  const [suggestion] = message.suggestions ?? []
+  if (!suggestion)
+    throw new Error(`expected a suggestion, got none`)
+  const [start, end] = suggestion.fix.range
+  return code.slice(0, start) + suggestion.fix.text + code.slice(end)
+}
+
+run({
+  name: RULE_NAME,
+  rule,
+  valid: [
+    // already using satisfies
+    $`
+      const handlers = {
+        start: startHandler,
+      } satisfies Record<string, Handler>
+    `,
+    // no annotation at all
+    $`
+      const handlers = {
+        start: startHandler,
+      }
+    `,
+    // finite key union: the annotation buys exhaustiveness checking
+    $`
+      const labels: Record<Status, string> = {
+        idle: 'Idle',
+        busy: 'Busy',
+      }
+    `,
+    // string literal union key
+    $`
+      const configs: Record<'recommended' | 'migration', Config> = {
+        recommended: a,
+        migration: b,
+      }
+    `,
+    // opaque value type: no evidence worth preserving
+    $`
+      const payload: Record<string, unknown> = {
+        id: 1,
+      }
+    `,
+    $`
+      const options: Record<string, any> = {
+        depth: 1,
+      }
+    `,
+    // empty literal is a mutable-map seed
+    $`
+      const cache: Record<string, Entry> = {}
+    `,
+    // written to via index assignment
+    $`
+      const counts: Record<string, number> = {
+        total: 0,
+      }
+      counts[key] = 1
+    `,
+    // written to via member assignment
+    $`
+      const query: Record<string, string> = {
+        page: '1',
+      }
+      query.limit = '10'
+    `,
+    // deleted from
+    $`
+      const query: Record<string, string> = {
+        page: '1',
+      }
+      delete query.page
+    `,
+    // incremented
+    $`
+      const counts: Record<string, number> = {
+        total: 0,
+      }
+      counts.total++
+    `,
+    // Object.assign target
+    $`
+      const query: Record<string, string> = {
+        page: '1',
+      }
+      Object.assign(query, extra)
+    `,
+    // spread means the key set is not statically known
+    $`
+      const merged: Record<string, string> = {
+        ...base,
+        page: '1',
+      }
+    `,
+    // let is reassignable
+    $`
+      let handlers: Record<string, Handler> = {
+        start: startHandler,
+      }
+    `,
+    // not an object literal
+    $`
+      const handlers: Record<string, Handler> = buildHandlers()
+    `,
+    // a named interface is not a widening annotation
+    $`
+      const config: AppConfig = {
+        mode: 'strict',
+      }
+    `,
+  ],
+  invalid: [
+    // Record<string, V>
+    {
+      code: $`
+        const handlers: Record<string, Handler> = {
+          start: startHandler,
+        }
+      `,
+      errors: (messages) => {
+        expect(messages).toHaveLength(1)
+        expect(messages[0].messageId).toBe('preferSatisfies')
+        expect(applySuggestion($`
+          const handlers: Record<string, Handler> = {
+            start: startHandler,
+          }
+        `, messages[0])).toBe($`
+          const handlers = {
+            start: startHandler,
+          } satisfies Record<string, Handler>
+        `)
+      },
+    },
+    // Record<number, V>
+    {
+      code: $`
+        const products: Record<number, Product> = {
+          1: widget,
+        }
+      `,
+      errors: [{ messageId: 'preferSatisfies' }],
+    },
+    // index signature
+    {
+      code: $`
+        const entities: { [key: string]: string } = {
+          amp: '&',
+        }
+      `,
+      errors: (messages) => {
+        expect(messages).toHaveLength(1)
+        expect(applySuggestion($`
+          const entities: { [key: string]: string } = {
+            amp: '&',
+          }
+        `, messages[0])).toBe($`
+          const entities = {
+            amp: '&',
+          } satisfies { [key: string]: string }
+        `)
+      },
+    },
+    // Readonly<Record<string, V>>
+    {
+      code: $`
+        const TITLES: Readonly<Record<string, string>> = {
+          seo: 'SEO',
+        }
+      `,
+      errors: [{ messageId: 'preferSatisfies' }],
+    },
+    // exported constant
+    {
+      code: $`
+        export const FIX_HINTS: Record<string, string> = {
+          'no-silent-catch': 'Handle the error.',
+        }
+      `,
+      errors: [{ messageId: 'preferSatisfies' }],
+    },
+    // structured value type
+    {
+      code: $`
+        const iconRelLabels: Record<string, { label: string, description: string }> = {
+          icon: { label: 'Icon', description: 'Favicon' },
+        }
+      `,
+      errors: [{ messageId: 'preferSatisfies' }],
+    },
+    // read-only usage elsewhere does not exempt it
+    {
+      code: $`
+        const labels: Record<string, string> = {
+          start: 'Start',
+        }
+        export function label(key: string) {
+          return labels[key]
+        }
+      `,
+      errors: [{ messageId: 'preferSatisfies' }],
+    },
+  ],
+})

--- a/src/rules/prefer-satisfies.ts
+++ b/src/rules/prefer-satisfies.ts
@@ -1,0 +1,172 @@
+import type { TSESTree } from '@typescript-eslint/utils'
+import { createEslintRule } from '../utils'
+
+export const RULE_NAME = 'prefer-satisfies'
+export type MessageIds = 'preferSatisfies' | 'useSatisfies'
+export type Options = []
+
+const OPEN_KEYS = new Set([
+  'TSStringKeyword',
+  'TSNumberKeyword',
+])
+
+const OPAQUE_VALUES = new Set([
+  'TSAnyKeyword',
+  'TSUnknownKeyword',
+])
+
+function typeName(node: TSESTree.TypeNode): string | null {
+  return node.type === 'TSTypeReference' && node.typeName.type === 'Identifier'
+    ? node.typeName.name
+    : null
+}
+
+/**
+ * A widening annotation is one that erases the object's key set: `Record<string, V>`,
+ * `Readonly<Record<string, V>>`, or a bare index signature. A finite key union
+ * (`Record<Status, V>`) is not widening -- it buys exhaustiveness, so it is left alone.
+ */
+function isWideningAnnotation(node: TSESTree.TypeNode): boolean {
+  // { [key: string]: V }
+  if (node.type === 'TSTypeLiteral') {
+    return node.members.length === 1
+      && node.members[0].type === 'TSIndexSignature'
+      && isOpenIndexSignature(node.members[0])
+  }
+
+  const name = typeName(node)
+  if (!name)
+    return false
+
+  const args = node.type === 'TSTypeReference' ? node.typeArguments?.params : undefined
+  if (!args)
+    return false
+
+  // Readonly<Record<string, V>> / Partial<Record<string, V>>
+  if ((name === 'Readonly' || name === 'Partial') && args.length === 1)
+    return isWideningAnnotation(args[0])
+
+  if (name !== 'Record' || args.length !== 2)
+    return false
+
+  return OPEN_KEYS.has(args[0].type) && !OPAQUE_VALUES.has(args[1].type)
+}
+
+function isOpenIndexSignature(member: TSESTree.TSIndexSignature): boolean {
+  const key = member.parameters[0]
+  const keyType = key?.type === 'Identifier' ? key.typeAnnotation?.typeAnnotation : undefined
+  const valueType = member.typeAnnotation?.typeAnnotation
+  return !!keyType
+    && !!valueType
+    && OPEN_KEYS.has(keyType.type)
+    && !OPAQUE_VALUES.has(valueType.type)
+}
+
+/** Keys are only evidence worth preserving when every one of them is statically present. */
+function hasStaticKeys(node: TSESTree.ObjectExpression): boolean {
+  return node.properties.length > 0
+    && node.properties.every(p => p.type === 'Property')
+}
+
+/**
+ * `satisfies` freezes the key set, so an object that is written to after
+ * declaration genuinely needs the wide annotation.
+ */
+function isMutated(references: TSESTree.Identifier[]): boolean {
+  return references.some((id) => {
+    const parent = id.parent
+
+    // Object.assign(target, ...)
+    if (parent?.type === 'CallExpression' && parent.arguments[0] === id) {
+      const callee = parent.callee
+      if (
+        callee.type === 'MemberExpression'
+        && callee.object.type === 'Identifier'
+        && callee.object.name === 'Object'
+        && callee.property.type === 'Identifier'
+        && callee.property.name === 'assign'
+      ) {
+        return true
+      }
+    }
+
+    if (parent?.type !== 'MemberExpression' || parent.object !== id)
+      return false
+
+    const grandparent = parent.parent
+    // x.a = v / x[k] = v
+    if (grandparent?.type === 'AssignmentExpression' && grandparent.left === parent)
+      return true
+    // x.a++ / x[k]--
+    if (grandparent?.type === 'UpdateExpression')
+      return true
+    // delete x[k]
+    return grandparent?.type === 'UnaryExpression' && grandparent.operator === 'delete'
+  })
+}
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'prefer `satisfies` over a widening type annotation on object literals',
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      preferSatisfies: 'Annotating with `{{annotation}}` discards the object\'s known keys. Use `satisfies` to keep them.',
+      useSatisfies: 'Replace the annotation with `satisfies {{annotation}}`.',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
+
+    return {
+      VariableDeclarator(node) {
+        const declaration = node.parent
+        if (declaration.type !== 'VariableDeclaration' || declaration.kind !== 'const')
+          return
+
+        if (node.id.type !== 'Identifier')
+          return
+
+        const annotation = node.id.typeAnnotation?.typeAnnotation
+        if (!annotation || !isWideningAnnotation(annotation))
+          return
+
+        if (node.init?.type !== 'ObjectExpression' || !hasStaticKeys(node.init))
+          return
+
+        const [variable] = sourceCode.getDeclaredVariables(node)
+        if (!variable)
+          return
+
+        const references = variable.references
+          .filter(ref => ref.identifier !== node.id)
+          .map(ref => ref.identifier as TSESTree.Identifier)
+
+        if (isMutated(references))
+          return
+
+        const annotationText = sourceCode.getText(annotation)
+        const data = { annotation: annotationText }
+
+        context.report({
+          node: node.id.typeAnnotation!,
+          messageId: 'preferSatisfies',
+          data,
+          suggest: [{
+            messageId: 'useSatisfies',
+            data,
+            fix: fixer => [
+              fixer.remove(node.id.typeAnnotation!),
+              fixer.insertTextAfter(node.init!, ` satisfies ${annotationText}`),
+            ],
+          }],
+        })
+      },
+    }
+  },
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,7 @@ const hasDocs = [
   'nuxt-no-unsafe-date',
   'nuxt-prefer-navigate-to-over-router-push-replace',
   'nuxt-prefer-nuxt-link-over-router-link',
+  'prefer-satisfies',
   'use-composables-must-use-reactivity',
   'vue-no-async-lifecycle-hook',
   'vue-no-nested-reactivity',


### PR DESCRIPTION
### Description

`Record<string, V>` on an object literal throws away the keys the literal actually declared, so `handlers.strat` typechecks and `keyof typeof handlers` is `string`. `satisfies` checks the same constraint and keeps them.

I scanned ~80 local repos for this before writing it: 560 `Record`-annotated literals, of which 326 are the widening case. Mostly SCREAMING_CASE lookup tables (`XML_ENTITIES`, `TAG_TO_HELPER`, `CATEGORY_TITLES`).

The other 234 are why the rule is narrow. A finite key union (`Record<Status, string>`) buys exhaustiveness that `satisfies` can't give back, so it's skipped. So are mutable maps, `unknown`/`any` values, spreads, `let`, and empty literals.

Reports a suggestion rather than an autofix. Narrowing surfaces real errors at other call sites and `--fix` shouldn't spring those on you across a repo.

Ported from the idea in [dmmulroy/anti-slop](https://github.com/dmmulroy/anti-slop)'s `no-known-value-widening` (Oxlint), scoped down and rewritten for ESLint.

Question: I put it at `warn` in the `nuxt` and `vue` configs alongside `no-silent-catch`. It might belong off-by-default instead given how much existing code it flags.

### Linked Issues

### Additional context

Verified against real files in `unhead`, `gscdump`, `og-image`, `unlighthouse` and `eslint-plugin-prompt` -- it reports the lookup tables and stays quiet on the mutated maps.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).