### PR TITLE
feat: add nuxt-no-redundant-component-imports rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The rules are organized into the following categories:
 | **Nuxt** | |
 | [`nuxt-await-navigate-to`](./src/rules/nuxt-await-navigate-to.md) | enforce awaiting `navigateTo()` calls |
 | [`nuxt-no-random`](./src/rules/nuxt-no-random.md) | disallow random values during SSR rendering |
+| [`nuxt-no-redundant-component-imports`](./src/rules/nuxt-no-redundant-component-imports.md) | disallow `#components` imports used only as Vue template tags |
 | [`nuxt-no-redundant-import-meta`](./src/rules/nuxt-no-redundant-import-meta.md) | disallow redundant `import.meta.server` or `import.meta.client` checks in scoped components |
 | [`nuxt-no-self-layer-alias`](./src/rules/nuxt-no-self-layer-alias.ts) | disallow `#layers/<name>` alias when importing from the same layer; prefer a relative path |
 | [`nuxt-no-side-effects-in-async-data-handler`](./src/rules/nuxt-no-side-effects-in-async-data-handler.md) | disallow side effects in async data handlers |

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import linkTrailingSlash from './rules/link-trailing-slash'
 import noSilentCatch from './rules/no-silent-catch'
 import nuxtAwaitNavigateTo from './rules/nuxt-await-navigate-to'
 import nuxtNoRandom from './rules/nuxt-no-random'
+import nuxtNoRedundantComponentImports from './rules/nuxt-no-redundant-component-imports'
 import nuxtNoRedundantImportMeta from './rules/nuxt-no-redundant-import-meta'
 import nuxtNoSelfLayerAlias from './rules/nuxt-no-self-layer-alias'
 import nuxtNoSideEffectsInAsyncDataHandler from './rules/nuxt-no-side-effects-in-async-data-handler'
@@ -109,6 +110,7 @@ const rules = defineRules({
   'no-silent-catch': noSilentCatch,
   'nuxt-await-navigate-to': nuxtAwaitNavigateTo,
   'nuxt-no-random': nuxtNoRandom,
+  'nuxt-no-redundant-component-imports': nuxtNoRedundantComponentImports,
   'nuxt-no-redundant-import-meta': nuxtNoRedundantImportMeta,
   'nuxt-no-self-layer-alias': nuxtNoSelfLayerAlias,
   'nuxt-no-side-effects-in-async-data-handler': nuxtNoSideEffectsInAsyncDataHandler,
@@ -328,6 +330,7 @@ plugin.configs!.nuxt = [
     rules: {
       'harlanzw/nuxt-await-navigate-to': 'error',
       'harlanzw/nuxt-no-random': 'error',
+      'harlanzw/nuxt-no-redundant-component-imports': 'warn',
       'harlanzw/nuxt-no-redundant-import-meta': 'error',
       'harlanzw/nuxt-no-self-layer-alias': 'warn',
       'harlanzw/nuxt-no-side-effects-in-async-data-handler': 'error',

--- a/src/rules/nuxt-no-redundant-component-imports.md
+++ b/src/rules/nuxt-no-redundant-component-imports.md
@@ -1,0 +1,73 @@
+# nuxt-no-redundant-component-imports
+
+> Disallow `#components` imports used only as Vue template tags
+
+Nuxt auto-imports components referenced as template tags. Explicit named imports
+for those tags add noise and duplicate Nuxt's generated import.
+
+This is a source clarity rule. Named `#components` imports are tree-shaken and
+remain appropriate when code needs the component value.
+
+## Incorrect
+
+```vue
+<script setup lang="ts">
+import { NuxtLink, UiButton } from '#components'
+</script>
+
+<template>
+  <NuxtLink to="/">
+    <UiButton>Home</UiButton>
+  </NuxtLink>
+</template>
+```
+
+## Correct
+
+```vue
+<template>
+  <NuxtLink to="/">
+    <UiButton>Home</UiButton>
+  </NuxtLink>
+</template>
+```
+
+Keep the import when the script needs the component value:
+
+```vue
+<script setup lang="ts">
+import { UiButton } from '#components'
+import { h } from 'vue'
+
+const button = h(UiButton)
+</script>
+```
+
+Aliased imports also remain valid because removing them would change the local
+template name:
+
+```vue
+<script setup lang="ts">
+import { UiSkeleton as SkeletonComponent } from '#components'
+</script>
+
+<template>
+  <SkeletonComponent />
+</template>
+```
+
+The rule is autofixable. It removes only unaliased imports referenced solely as
+template tags and preserves script references, dynamic `:is` bindings, type
+imports, and aliases. An import that carries a comment between its specifiers is
+reported without a fix, because removing one specifier would re-attach the
+comment to the next one.
+
+## When Not To Use It
+
+Turn the rule off when the project sets `components: false` in `nuxt.config`.
+Template auto-import is disabled there, so the explicit `#components` import is
+required and removing it breaks the component.
+
+## Further reading
+
+* [Nuxt components directory](https://nuxt.com/docs/4.x/directory-structure/app/components)

--- a/src/rules/nuxt-no-redundant-component-imports.test.ts
+++ b/src/rules/nuxt-no-redundant-component-imports.test.ts
@@ -1,0 +1,212 @@
+import { unindent as $ } from 'eslint-vitest-rule-tester'
+import { runVue } from './_test'
+import rule, { RULE_NAME } from './nuxt-no-redundant-component-imports'
+
+runVue({
+  name: RULE_NAME,
+  rule,
+  valid: [
+    {
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import { UiButton } from '#components'
+
+        const button = h(UiButton)
+        </script>
+
+        <template>
+          <component :is="button" />
+        </template>
+      `,
+    },
+    {
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import { UiSkeleton as SkeletonComponent } from '#components'
+        </script>
+
+        <template>
+          <SkeletonComponent />
+        </template>
+      `,
+    },
+    {
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import { UiButton } from '#components'
+        </script>
+
+        <template>
+          <component :is="UiButton" />
+        </template>
+      `,
+    },
+    {
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import type { UiButton } from '#components'
+
+        type Button = typeof UiButton
+        </script>
+      `,
+    },
+    {
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import { UiButton } from './components'
+        </script>
+
+        <template>
+          <UiButton />
+        </template>
+      `,
+    },
+  ],
+  invalid: [
+    {
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import { UiButton } from '#components'
+        </script>
+
+        <template>
+          <UiButton />
+        </template>
+      `,
+      output: $`
+        <script setup lang="ts">
+        </script>
+
+        <template>
+          <UiButton />
+        </template>
+      `,
+      errors: [{ messageId: 'redundantComponentImports', data: { components: 'UiButton' } }],
+    },
+    {
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import { NuxtLink, UiButton, UiCard } from '#components'
+
+        const card = h(UiCard)
+        </script>
+
+        <template>
+          <NuxtLink to="/">
+            <ui-button>Home</ui-button>
+          </NuxtLink>
+          <component :is="card" />
+        </template>
+      `,
+      output: $`
+        <script setup lang="ts">
+        import { UiCard } from '#components'
+
+        const card = h(UiCard)
+        </script>
+
+        <template>
+          <NuxtLink to="/">
+            <ui-button>Home</ui-button>
+          </NuxtLink>
+          <component :is="card" />
+        </template>
+      `,
+      errors: [{ messageId: 'redundantComponentImports', data: { components: 'NuxtLink, UiButton' } }],
+    },
+    {
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import {
+          NuxtLink,
+          UiButton,
+          UiCard,
+          UiSkeleton as SkeletonComponent,
+        } from '#components'
+
+        const card = h(UiCard)
+        </script>
+
+        <template>
+          <NuxtLink to="/" />
+          <UiButton />
+          <SkeletonComponent />
+          <component :is="card" />
+        </template>
+      `,
+      output: $`
+        <script setup lang="ts">
+        import {
+          UiCard,
+          UiSkeleton as SkeletonComponent,
+        } from '#components'
+
+        const card = h(UiCard)
+        </script>
+
+        <template>
+          <NuxtLink to="/" />
+          <UiButton />
+          <SkeletonComponent />
+          <component :is="card" />
+        </template>
+      `,
+      errors: [{ messageId: 'redundantComponentImports', data: { components: 'NuxtLink, UiButton' } }],
+    },
+    {
+      // a comment between specifiers would re-attach to the wrong import, so report only
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import {
+          // navigation
+          NuxtLink,
+          UiCard,
+        } from '#components'
+
+        const card = h(UiCard)
+        </script>
+
+        <template>
+          <NuxtLink to="/" />
+          <component :is="card" />
+        </template>
+      `,
+      output: null,
+      errors: [{ messageId: 'redundantComponentImports', data: { components: 'NuxtLink' } }],
+    },
+    {
+      // the whole declaration goes, so its comments go with it
+      filename: 'Component.vue',
+      code: $`
+        <script setup lang="ts">
+        import {
+          // navigation
+          NuxtLink,
+        } from '#components'
+        </script>
+
+        <template>
+          <NuxtLink to="/" />
+        </template>
+      `,
+      output: $`
+        <script setup lang="ts">
+        </script>
+
+        <template>
+          <NuxtLink to="/" />
+        </template>
+      `,
+      errors: [{ messageId: 'redundantComponentImports', data: { components: 'NuxtLink' } }],
+    },
+  ],
+})

--- a/src/rules/nuxt-no-redundant-component-imports.ts
+++ b/src/rules/nuxt-no-redundant-component-imports.ts
@@ -1,0 +1,163 @@
+import type { TSESTree } from '@typescript-eslint/utils'
+import type { RuleFixer } from '@typescript-eslint/utils/ts-eslint'
+import { createEslintRule } from '../utils'
+import { defineTemplateBodyVisitor, isVueParser } from '../vue-utils'
+
+export const RULE_NAME = 'nuxt-no-redundant-component-imports'
+export type MessageIds = 'redundantComponentImports'
+export type Options = []
+
+interface ComponentImport {
+  declaration: TSESTree.ImportDeclaration
+  importedName: string
+  localName: string
+  specifier: TSESTree.ImportSpecifier
+}
+
+function removeImport(
+  fixer: RuleFixer,
+  sourceCode: Readonly<{ text: string }>,
+  declaration: TSESTree.ImportDeclaration,
+) {
+  let end = declaration.range[1]
+  while (sourceCode.text[end] === ' ' || sourceCode.text[end] === '\t')
+    end++
+
+  if (sourceCode.text[end] === '\r' && sourceCode.text[end + 1] === '\n')
+    end += 2
+  else if (sourceCode.text[end] === '\n')
+    end++
+
+  return fixer.removeRange([declaration.range[0], end])
+}
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow #components imports that Nuxt already auto-imports in Vue templates',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      redundantComponentImports: 'Remove {{components}} from #components; Nuxt auto-imports components used only in the template.',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    if (!context.filename.endsWith('.vue') || !isVueParser(context))
+      return {}
+
+    const sourceCode = context.sourceCode
+    const importsByDeclaration = new Map<TSESTree.ImportDeclaration, ComponentImport[]>()
+    const templateExpressionReferences = new Set<string>()
+
+    const reportRedundantImports = () => {
+      for (const [declaration, componentImports] of importsByDeclaration) {
+        const redundant = componentImports.filter((componentImport) => {
+          if (componentImport.importedName !== componentImport.localName)
+            return false
+          if (templateExpressionReferences.has(componentImport.localName))
+            return false
+
+          const [variable] = sourceCode.getDeclaredVariables(componentImport.specifier as any)
+          const references = variable?.references ?? []
+          const hasTemplateTagReference = references.some(reference => reference.identifier.parent === componentImport.specifier)
+          const hasOtherReference = references.some(reference => reference.identifier.parent !== componentImport.specifier)
+          return hasTemplateTagReference && !hasOtherReference
+        })
+
+        if (redundant.length === 0)
+          continue
+
+        const redundantSpecifiers = new Set(redundant.map(componentImport => componentImport.specifier))
+        const components = redundant.map(componentImport => componentImport.localName).join(', ')
+
+        context.report({
+          node: declaration,
+          messageId: 'redundantComponentImports',
+          data: { components },
+          fix(fixer) {
+            const retained = declaration.specifiers.filter(specifier => !redundantSpecifiers.has(specifier as TSESTree.ImportSpecifier))
+            if (retained.length === 0)
+              return removeImport(fixer, sourceCode, declaration)
+
+            // Removing one specifier out of several would re-attach any comment
+            // between them to the wrong import. Report without fixing instead.
+            if (sourceCode.getCommentsInside(declaration).length > 0)
+              return null
+
+            const fixes = []
+            let groupStart = -1
+
+            for (let index = 0; index <= declaration.specifiers.length; index++) {
+              const specifier = declaration.specifiers[index]
+              const isRedundant = specifier && redundantSpecifiers.has(specifier as TSESTree.ImportSpecifier)
+
+              if (isRedundant && groupStart === -1) {
+                groupStart = index
+                continue
+              }
+              if (isRedundant || groupStart === -1)
+                continue
+
+              const first = declaration.specifiers[groupStart]!
+              const last = declaration.specifiers[index - 1]!
+              const next = declaration.specifiers[index]
+
+              if (next) {
+                fixes.push(fixer.removeRange([first.range[0], next.range[0]]))
+              }
+              else {
+                const comma = sourceCode.getTokenBefore(first as any)
+                if (!comma || comma.value !== ',')
+                  return null
+                fixes.push(fixer.removeRange([comma.range[0], last.range[1]]))
+              }
+
+              groupStart = -1
+            }
+
+            return fixes
+          },
+        })
+      }
+    }
+
+    return defineTemplateBodyVisitor(context, {
+      Identifier(node) {
+        templateExpressionReferences.add(node.name)
+      },
+      'VElement:exit': function (node) {
+        if (node.parent.type === 'VDocumentFragment')
+          reportRedundantImports()
+      },
+    }, {
+      ImportDeclaration(node) {
+        if (node.source.value !== '#components' || node.importKind === 'type')
+          return
+
+        const componentImports = node.specifiers.flatMap((specifier): ComponentImport[] => {
+          if (
+            specifier.type !== 'ImportSpecifier'
+            || specifier.importKind === 'type'
+            || specifier.imported.type !== 'Identifier'
+          ) {
+            return []
+          }
+
+          return [{
+            declaration: node,
+            importedName: specifier.imported.name,
+            localName: specifier.local.name,
+            specifier,
+          }]
+        })
+
+        if (componentImports.length > 0)
+          importsByDeclaration.set(node, componentImports)
+      },
+    })
+  },
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,7 @@ const hasDocs = [
   'link-require-href',
   'link-trailing-slash',
   'nuxt-no-random',
+  'nuxt-no-redundant-component-imports',
   'nuxt-no-redundant-import-meta',
   'nuxt-no-side-effects-in-setup',
   'nuxt-no-unsafe-date',


### PR DESCRIPTION
### Description

Nuxt already auto-imports any component you reference as a template tag, so `import { UiButton } from '#components'` next to `<UiButton />` is duplicating work the generated code does anyway.

The rule only fires when the import has no other use. It stays quiet on script references (`h(UiButton)`, `InstanceType<typeof UiButton>`, `defineExpose({ UiButton })`), dynamic `:is` bindings, type imports, and aliased imports, since removing an alias would change the local tag name.

Autofixable, with one exception: if a comment sits between the specifiers, removing one would leave the comment describing the next import instead, so it reports without fixing.

### Linked Issues

### Additional context

I ran it over every `.vue` file in my local repos that imports from `#components`. One real hit, in the `nuxt-scripts` playground, fixed correctly.

Docs note a case to watch: a project with `components: false` in `nuxt.config` has no template auto-import, so the explicit import is required there and the rule should be off.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).