### PR TITLE
feat: shared base config blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,266 +1,40 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
-This is `eslint-plugin-harlanzw` - Harlan's experimental ESLint rules for Vue projects, particularly focused on link hygiene, Nuxt best practices, and Vue reactivity patterns. The plugin provides 23 link/nuxt/vue rules, 12 AI deslop rules for cleaning AI-generated content, and 21 prompt linting rules.
-
-## Development Commands
+`eslint-plugin-harlanzw`: experimental ESLint rules for Vue/Nuxt projects. Three families: link hygiene + Nuxt + Vue reactivity rules, AI-deslop rules for `content/**/*.md`, and prompt-linting rules. Rules may eventually be submitted upstream to the official Vue ESLint plugin.
 
 ```bash
-# Install dependencies
-pnpm install
-
-# Build the plugin
-pnpm build
-
-# Development mode (stub build for faster iteration)
-pnpm dev
-
-# Run tests
+pnpm dev        # stub build; pnpm lint needs this first
+pnpm build      # unbuild, ESM + d.ts to dist/
 pnpm test
-
-# Lint the codebase (requires pnpm dev first)
-pnpm lint
-
-# Type checking
 pnpm typecheck
-
-# Release process (build + version bump + publish)
 pnpm release
 ```
 
-## Testing
+## Layout
 
-- Uses **Vitest** as the test runner with globals enabled
-- Uses **eslint-vitest-rule-tester** for testing ESLint rules
-- Test files are located alongside rule files with `.test.ts` suffix
-- Common test utilities are in `src/rules/_test.ts`
-- Each rule should have comprehensive test cases covering valid/invalid scenarios
-- Every new rule **must** have a `.test.ts` file and an entry in the rules table in `README.md`
+- `src/index.ts` — plugin export, registers every rule
+- `src/rules/` — one rule per file, plus `<rule>.test.ts` beside it and `<rule>.md` when the rule needs long docs
+- `src/utils.ts` — `createEslintRule` (auto-generates the docs URL) and rule helpers
+- `src/base.ts` — `base()`, the shared override blocks (ignores, node globals, test/markdown/example relaxations)
+- `src/vue-utils.ts` — Vue AST helpers (`isVueParser`, `defineTemplateBodyVisitor`, `trackVueImports`, `trackNonVueImports`, `VUE_REACTIVITY_APIS`)
+- `src/ast-utils.ts` — general AST helpers (calls, awaits, returns, scope)
+- `playground/` — Nuxt 4 app for manual rule testing
 
-## Project Architecture
+Shared configs: `link`, `nuxt`, `vue`, `recommended` (those three), `content` (deslop), `prompt:recommended`, `prompt:strict`, `prompt:skill`. `base` is opt in and turns rules off rather than on.
 
-### Core Structure
-- `src/index.ts` - Main plugin export, registers all rules
-- `src/rules/` - Individual ESLint rule implementations
-- `src/utils.ts` - Rule creation utilities and helpers
-- `src/vue-utils.ts` - Vue-specific AST utilities and helpers
-- `src/ast-utils.ts` - General AST manipulation utilities
+`createReactivityChecker` returns `hasReactivityInStatement`/`hasReactivityInExpression` and is shared by the composable rules; reach for it rather than re-walking for reactivity calls.
 
-### Rule Development Pattern
-Each rule follows a consistent pattern:
-1. Rule file (e.g., `vue-no-ref-access.ts`)
-2. Test file (e.g., `vue-no-ref-access.test.ts`)
-3. Documentation file (e.g., `vue-no-ref-access.md`) - for rules with extensive docs
-4. Rules are created using the `createEslintRule` helper from `src/utils.ts`
+## Every new rule needs
 
-### Plugin Rules (23 link/nuxt/vue + 10 deslop + 21 prompt)
+1. a `.test.ts` beside it, covering valid and invalid cases
+2. an entry in the rules table in `README.md`
 
-**Link rules (8):**
-- `link-ascii-only` - Ensure link URLs contain only ASCII characters
-- `link-lowercase` - Ensure link URLs do not contain uppercase characters
-- `link-no-double-slashes` - Ensure link URLs do not contain consecutive slashes
-- `link-no-underscores` - Ensure link URLs do not contain underscores
-- `link-no-whitespace` - Ensure link URLs do not contain whitespace characters
-- `link-require-descriptive-text` - Require descriptive link text
-- `link-require-href` - Require href/to attribute on link elements
-- `link-trailing-slash` - Enforce trailing slash consistency on link URLs
+Tests run on Vitest (globals enabled) via `eslint-vitest-rule-tester`; shared helpers live in `src/rules/_test.ts`.
 
-**Nuxt rules (8):**
-- `nuxt-await-navigate-to` - Enforces awaiting navigateTo() calls in Nuxt
-- `nuxt-no-random` - Prevents Math.random() in SSR contexts (hydration mismatch)
-- `nuxt-no-redundant-import-meta` - Prevents redundant import.meta checks in scoped components
-- `nuxt-no-side-effects-in-async-data-handler` - Prevents side effects in async data handlers
-- `nuxt-no-side-effects-in-setup` - Prevents side effects in Vue setup functions
-- `nuxt-no-unsafe-date` - Warns against Date APIs that differ between server/client
-- `nuxt-prefer-navigate-to-over-router-push-replace` - Prefer navigateTo over router methods
-- `nuxt-prefer-nuxt-link-over-router-link` - Prefer NuxtLink over RouterLink components
+## Vue AST rules
 
-**Vue rules (7):**
-- `vue-no-faux-composables` - Prevents fake composables that don't use Vue reactivity
-- `vue-no-nested-reactivity` - Prevents mixing ref() and reactive() patterns
-- `vue-no-passing-refs-as-props` - Requires unwrapping refs before passing as props
-- `vue-no-reactive-destructuring` - Prevents destructuring reactive objects (loses reactivity)
-- `vue-no-ref-access-in-templates` - Prevents using .value in Vue templates
-- `vue-no-torefs-on-props` - Prevents using toRefs() on props object
-- `vue-require-composable-prefix` - Enforces use* prefix for functions using Vue reactivity
+`vue-eslint-parser` has behaviours that will silently produce a rule that never fires (lowercase element names, mandatory dual visitors, `filename: 'test.vue'` in tests). Read [docs/vue-ast-rules.md](docs/vue-ast-rules.md) before writing or debugging one.
 
-**AI Deslop rules (10):** Target `content/**/*.md` — clean AI-generated slop from content
-- `ai-deslop-adverbs` - Remove unnecessary adverbs ("significantly", "fundamentally")
-- `ai-deslop-autolink` - Auto-link first mention of tech terms to canonical URLs
-- `ai-deslop-buzzwords` - Replace AI buzzwords with plain alternatives ("leverage" → "use")
-- `ai-deslop-casing` - Enforce correct tech term casing ("github" → "GitHub")
-- `ai-deslop-filler` - Remove filler phrases ("it's worth noting that", "at the end of the day")
-- `ai-deslop-hedging` - Remove hedging/qualifying words ("very", "really", "quite", "just")
-- `ai-deslop-no-em-dash` - Replace em dashes with plain dashes ("—" → " - ")
-- `ai-deslop-no-exclamation` - Remove exclamation marks from content prose
-- `ai-deslop-passive-voice` - Flag passive voice constructions ("is generated" → rewrite actively)
-- `ai-deslop-weak-opener` - Flag weak sentence openers ("There is", "It is possible to")
-- `ai-deslop-frontmatter-spacing` - Remove empty lines inside YAML frontmatter
-- `ai-deslop-vue-ts-lang` - Require `lang="ts"` on Vue `<script>` blocks in code examples
+## Build
 
-**Shared configs:** `link`, `nuxt`, `vue`, `recommended` (all three), `content` (deslop), `prompt:recommended`, `prompt:strict`, `prompt:skill`
-
-### Key Utilities
-- `VUE_REACTIVITY_APIS` - Set of all Vue reactivity function names
-- `createEslintRule` - Main rule creation helper with automatic docs URL generation
-- `createReactivityChecker` - Factory returning `hasReactivityInStatement`/`hasReactivityInExpression` helpers, shared by composable rules
-- Vue template visitor support for SFC analysis
-- Import tracking for Vue reactivity APIs (`trackVueImports`, `trackNonVueImports`)
-- AST utilities for function calls, awaits, returns, and scope analysis
-
-### Build Configuration
-- Uses **unbuild** for building with TypeScript declaration files
-- Externals: `@typescript-eslint/utils`
-- Inlined: `@antfu/utils`
-- Output: ESM format in `dist/` directory
-
-### Playground
-The `playground/` directory contains a Nuxt application for testing the rules:
-- Nuxt 4.x with ESLint integration
-- Examples of each rule in action
-- Can be used for manual testing and development
-
-## Vue AST Development Guidelines
-
-### Working with Vue Single File Components (SFCs)
-This plugin supports Vue SFC files through the `vue-eslint-parser`. Here are critical patterns for Vue AST rules:
-
-#### 1. Vue Parser Detection and Setup
-```typescript
-import { defineTemplateBodyVisitor, isVueParser } from '../vue-utils'
-
-export default createEslintRule({
-  create(context) {
-    if (isVueParser(context as any)) {
-      const scriptVisitor = {
-        // Script section visitor logic
-      }
-
-      const templateVisitor = {
-        // Template section visitor logic
-      }
-
-      return defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
-    }
-
-    // Fallback for non-Vue files
-    return {
-      // Regular AST visitors for .ts/.js files
-    }
-  }
-})
-```
-
-#### 2. Critical Vue Parser Behaviors
-- **Element names are lowercase**: `<RouterLink>` becomes `routerlink` in AST
-- **Both visitors required**: Always provide both `templateVisitor` and `scriptVisitor` to `defineTemplateBodyVisitor`
-- **Node structure**: Vue template nodes use `VElement`, `VAttribute` etc. instead of regular JS AST nodes
-
-#### 3. Testing Vue SFC Rules
-```typescript
-import { runVue } from './_test'
-
-runVue({
-  name: 'rule-name (Vue SFC)',
-  rule,
-  valid: [
-    {
-      code: `
-        <template>
-          <NuxtLink to="/page">Valid</NuxtLink>
-        </template>
-      `,
-      filename: 'test.vue', // Required for Vue SFC tests
-    },
-  ],
-  invalid: [
-    {
-      code: `
-        <template>
-          <RouterLink to="/page">Invalid</RouterLink>
-        </template>
-      `,
-      filename: 'test.vue',
-      errors: [{ messageId: 'errorId' }],
-      output: `
-        <template>
-          <NuxtLink to="/page">Fixed</NuxtLink>
-        </template>
-      `,
-    },
-  ],
-})
-```
-
-#### 4. Common Vue Template Visitors
-```typescript
-const templateVisitor = {
-  VElement(node: any) {
-    // All Vue elements (div, components, etc.)
-    // Remember: node.name is lowercase!
-    if (node.name === 'routerlink') { // Not 'RouterLink'!
-      // Handle RouterLink elements
-    }
-  },
-
-  VAttribute(node: any) {
-    // All Vue attributes (:prop, @click, etc.)
-  },
-
-  VExpressionContainer(node: any) {
-    // Vue template expressions {{ }} and v-bind values
-  }
-}
-```
-
-#### 5. Dual File Type Support Pattern
-Many rules need to work in both Vue SFC templates and JSX/TSX:
-
-```typescript
-create(context) {
-  if (isVueParser(context as any)) {
-    // Vue SFC template handling
-    return defineTemplateBodyVisitor(context, {
-      VElement(node: any) {
-        if (node.name === 'routerlink') { // lowercase!
-          context.report(/* ... */)
-        }
-      }
-    }, {})
-  }
-
-  // JSX/TSX handling
-  return {
-    JSXElement(node: any) {
-      if (node.openingElement?.name?.name === 'RouterLink') { // PascalCase
-        context.report(/* ... */)
-      }
-    }
-  }
-}
-```
-
-#### 6. Common Pitfalls
-- **Missing null checks**: Always check `node.init` before accessing properties
-- **Case sensitivity**: Vue elements are lowercase, JSX elements preserve case
-- **Missing script visitor**: Always provide both visitors to avoid parser errors
-- **Wrong filename**: Vue SFC tests need `filename: 'test.vue'`
-
-### Example: Complete Vue AST Rule
-See `nuxt-prefer-nuxt-link-over-router-link.ts` for a complete example that:
-- ✅ Detects Vue parser correctly
-- ✅ Handles lowercase element names
-- ✅ Provides both template and script visitors
-- ✅ Supports both Vue SFC and JSX files
-- ✅ Has comprehensive tests for both file types
-
-## Development Notes
-
-- Rules target Vue 3 and Nuxt applications specifically
-- Heavy use of TypeScript AST parsing via `@typescript-eslint/utils`
-- Support for both `.vue` SFC files and TypeScript files
-- Rules are designed to work with both script setup and composition API patterns
-- Plugin follows the experimental rule pattern - rules may be submitted to official Vue ESLint plugin later
+unbuild. `@typescript-eslint/utils` stays external; `@antfu/utils` is inlined.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,48 @@ export default harlanzw({
 })
 ```
 
+### Shared Base
+
+`base` carries the override blocks that were copy-pasted into every repo: the shared ignore set, node globals, and relaxations for test files, markdown code fences, and example manifests. It is opt in.
+
+```js
+import antfu from '@antfu/eslint-config'
+import { harlanzw } from 'eslint-plugin-harlanzw'
+
+export default antfu(
+  { type: 'lib' },
+  ...harlanzw({
+    base: true, // or { type: 'app', ignores: ['docs/**'] }
+    nuxt: true,
+    vue: true,
+  }),
+)
+```
+
+`type` defaults to `'lib'`, which also turns off `ts/explicit-function-return-type`. `ignores` appends to the shared set.
+
+Every rule in these blocks is set to `off`, and flat config ignores an `off` entry for a rule whose plugin is absent. So the blocks are safe with any preset, and need no dependency on `@antfu/eslint-config`.
+
+Spread them without the rule presets when you only want the shared overrides:
+
+```js
+import { base } from 'eslint-plugin-harlanzw'
+
+export default antfu({ type: 'lib' }, ...base())
+```
+
+The base blocks come first in the returned array, so put `harlanzw()` after the preset whose rules it relaxes.
+
+Contents:
+
+| Block | Applies to | Turns off |
+| --- | --- | --- |
+| `harlanzw/base/ignores` | global | `CLAUDE.md`, `AGENTS.md`, `.claude`, `.cursor`, `.data`, fixtures, `playground`, `worker-configuration.d.ts` |
+| `harlanzw/base/rules` | all files | `no-use-before-define`, `node/prefer-global/process`, `node/prefer-global/buffer` (+ `ts/explicit-function-return-type` for libs) |
+| `harlanzw/base/tests` | test files | `no-console`, `ts/no-unsafe-function-type`, `antfu/no-top-level-await`, `e18e/prefer-static-regex` |
+| `harlanzw/base/markdown` | `**/*.md/**` | `no-console`, tabs, `style/max-statements-per-line`, `e18e/prefer-static-regex`, unused imports |
+| `harlanzw/base/examples` | `examples/**/package.json` | pnpm catalog rules |
+
 ### Extra Configs
 
 Pass additional flat configs as extra arguments:

--- a/docs/vue-ast-rules.md
+++ b/docs/vue-ast-rules.md
@@ -1,0 +1,125 @@
+# Writing Vue AST Rules
+
+Vue SFC support comes from `vue-eslint-parser`. These are the patterns that aren't obvious from the parser's docs.
+
+## Parser detection and setup
+
+```typescript
+import { defineTemplateBodyVisitor, isVueParser } from '../vue-utils'
+
+export default createEslintRule({
+  create(context) {
+    if (isVueParser(context as any)) {
+      const scriptVisitor = {
+        // script section
+      }
+
+      const templateVisitor = {
+        // template section
+      }
+
+      return defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+    }
+
+    // .ts/.js fallback
+    return {}
+  }
+})
+```
+
+## Parser behaviours that bite
+
+- **Element names are lowercase.** `<RouterLink>` arrives as `routerlink`.
+- **Both visitors are required.** Passing only a template visitor to `defineTemplateBodyVisitor` causes parser errors.
+- **Template nodes are `VElement`, `VAttribute`, `VExpressionContainer`**, not regular JS AST nodes.
+- **Null checks.** Check `node.init` before touching its properties.
+
+## Template visitors
+
+```typescript
+const templateVisitor = {
+  VElement(node: any) {
+    if (node.name === 'routerlink') { // lowercase, not 'RouterLink'
+      // …
+    }
+  },
+
+  VAttribute(node: any) {
+    // :prop, @click, …
+  },
+
+  VExpressionContainer(node: any) {
+    // {{ }} and v-bind values
+  }
+}
+```
+
+## Dual file type support
+
+Rules that cover both Vue SFC templates and JSX/TSX have to handle the casing difference:
+
+<!-- eslint-skip -->
+```typescript
+create(context) {
+  if (isVueParser(context as any)) {
+    return defineTemplateBodyVisitor(context, {
+      VElement(node: any) {
+        if (node.name === 'routerlink') { // lowercase
+          context.report(/* … */)
+        }
+      }
+    }, {})
+  }
+
+  return {
+    JSXElement(node: any) {
+      if (node.openingElement?.name?.name === 'RouterLink') { // PascalCase
+        context.report(/* … */)
+      }
+    }
+  }
+}
+```
+
+## Testing
+
+Vue SFC tests need `filename: 'test.vue'`, or the parser never engages.
+
+```typescript
+import { runVue } from './_test'
+
+runVue({
+  name: 'rule-name (Vue SFC)',
+  rule,
+  valid: [
+    {
+      code: `
+        <template>
+          <NuxtLink to="/page">Valid</NuxtLink>
+        </template>
+      `,
+      filename: 'test.vue',
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        <template>
+          <RouterLink to="/page">Invalid</RouterLink>
+        </template>
+      `,
+      filename: 'test.vue',
+      errors: [{ messageId: 'errorId' }],
+      output: `
+        <template>
+          <NuxtLink to="/page">Fixed</NuxtLink>
+        </template>
+      `,
+    },
+  ],
+})
+```
+
+## Reference implementation
+
+`src/rules/nuxt-prefer-nuxt-link-over-router-link.ts` covers parser detection, lowercase element names, both visitors, SFC plus JSX, and tests for both file types.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,7 @@
 import antfu from '@antfu/eslint-config'
+// Dogfood the shared base from this package (requires `pnpm dev` for the stub build).
+// eslint-disable-next-line antfu/no-import-dist
+import { base } from './dist/index.mjs'
 
 export default antfu(
   {
@@ -9,34 +12,12 @@ export default antfu(
       },
     },
   },
-  {
-    ignores: ['playground/**', 'src/rules/*.md', 'CLAUDE.md'],
-  },
-  // Markdown code blocks in rule docs contain multi-root Vue/JSX examples
-  {
-    files: ['src/rules/*.md/**'],
-    rules: {
-      'no-tabs': 'off',
-      'style/no-tabs': 'off',
-    },
-  },
-  {
-    files: ['fixtures/**/*.ts'],
-    rules: {
-      'no-unused-vars': 'off',
-      'unused-imports/no-unused-vars': 'off',
-      'ts/explicit-function-return-type': 'off',
-    },
-  },
+  // Rule docs contain multi-root Vue/JSX examples that antfu's markdown pass cannot parse.
+  ...base({ ignores: ['src/rules/*.md'] }),
   {
     files: ['src/prompt/**/*.ts'],
     rules: {
       'no-cond-assign': 'off',
-    },
-  },
-  {
-    rules: {
-      'ts/explicit-function-return-type': 'off',
     },
   },
 )

--- a/src/base.test.ts
+++ b/src/base.test.ts
@@ -1,0 +1,96 @@
+import type { Linter as LinterTypes } from 'eslint'
+import { Linter } from 'eslint'
+import { describe, expect, it } from 'vitest'
+import { base } from './base'
+import harlanzw from './index'
+
+const linter = new Linter()
+
+function lint(code: string, configs: LinterTypes.Config[], filename: string) {
+  return linter.verify(code, configs, filename).map(m => m.ruleId)
+}
+
+function blockNamed(configs: LinterTypes.Config[], name: string) {
+  const block = configs.find(c => c.name === name)
+  if (!block)
+    throw new Error(`Expected a config block named ${name}`)
+  return block
+}
+
+const USE_BEFORE_DEFINE = 'foo()\nfunction foo() {}\n'
+
+describe('base', () => {
+  it('turns off rules the preset before it enabled', () => {
+    const strict: LinterTypes.Config[] = [
+      { files: ['**/*.js'], rules: { 'no-use-before-define': 'error' } },
+    ]
+
+    expect(lint(USE_BEFORE_DEFINE, strict, 'src/a.js')).toEqual(['no-use-before-define'])
+    expect(lint(USE_BEFORE_DEFINE, [...strict, ...base()], 'src/a.js')).toEqual([])
+  })
+
+  it('relaxes test files without relaxing source files', () => {
+    const configs = [
+      { files: ['**/*.js'], rules: { 'no-console': 'error' } } as LinterTypes.Config,
+      ...base(),
+    ]
+
+    expect(lint('console.log(1)\n', configs, 'src/a.js')).toEqual(['no-console'])
+    expect(lint('console.log(1)\n', configs, 'src/a.test.js')).toEqual([])
+    expect(lint('console.log(1)\n', configs, 'test/a.js')).toEqual([])
+    expect(lint('console.log(1)\n', configs, 'tests/nested/a.js')).toEqual([])
+  })
+
+  it('relaxes code fences in markdown', () => {
+    const configs = [
+      { files: ['**/*.md/**'], rules: { 'no-console': 'error' } } as LinterTypes.Config,
+      ...base(),
+    ]
+
+    expect(lint('console.log(1)\n', configs, 'README.md/0.js')).toEqual([])
+  })
+
+  it('drops the return type rule for libraries but not apps', () => {
+    expect(blockNamed(base(), 'harlanzw/base/rules').rules)
+      .toHaveProperty('ts/explicit-function-return-type', 'off')
+
+    expect(blockNamed(base({ type: 'app' }), 'harlanzw/base/rules').rules)
+      .not
+      .toHaveProperty('ts/explicit-function-return-type')
+  })
+
+  it('appends extra ignores to the shared set', () => {
+    const ignores = blockNamed(base({ ignores: ['docs/**'] }), 'harlanzw/base/ignores').ignores
+
+    expect(ignores).toContain('docs/**')
+    expect(ignores).toContain('playground/**')
+  })
+})
+
+describe('harlanzw({ base })', () => {
+  const off = { link: false, nuxt: false, vue: false, prompt: false, content: false, pnpm: false } as const
+
+  it('is opt in', () => {
+    const names = harlanzw(off).map(c => c.name)
+
+    expect(names).toEqual([])
+  })
+
+  it('emits the base blocks before the rule configs', () => {
+    const configs = harlanzw({ ...off, base: true, nuxt: true })
+    const names = configs.map(c => c.name)
+
+    expect(names[0]).toBe('harlanzw/base/ignores')
+    expect(names).toContain('harlanzw/nuxt')
+    expect(names.indexOf('harlanzw/base/examples')).toBeLessThan(names.indexOf('harlanzw/nuxt'))
+  })
+
+  it('forwards base options', () => {
+    const configs = harlanzw({ ...off, base: { type: 'app', ignores: ['tmp/**'] } })
+
+    expect(blockNamed(configs, 'harlanzw/base/ignores').ignores).toContain('tmp/**')
+    expect(blockNamed(configs, 'harlanzw/base/rules').rules)
+      .not
+      .toHaveProperty('ts/explicit-function-return-type')
+  })
+})

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,0 +1,107 @@
+import type { Linter } from 'eslint'
+
+/**
+ * Overrides that were copy-pasted into every repo before this existed.
+ *
+ * Every rule here is set to `off`. Flat config ignores an `off` entry for a rule
+ * whose plugin is not registered, so these blocks are safe without depending on
+ * `@antfu/eslint-config` or any of the plugins it loads.
+ */
+export interface BaseOptions {
+  /**
+   * `lib` also turns off `ts/explicit-function-return-type`.
+   *
+   * @default 'lib'
+   */
+  type?: 'lib' | 'app'
+  /**
+   * Paths to ignore on top of the shared ignore set.
+   */
+  ignores?: string[]
+}
+
+/** Ignored everywhere. Agent files are linted by the prompt configs instead. */
+const BASE_IGNORES = [
+  'CLAUDE.md',
+  'AGENTS.md',
+  '.claude/**',
+  '.cursor/**',
+  '.data/**',
+  '**/test/fixtures/**',
+  '**/fixtures/**',
+  'playground/**',
+  '**/worker-configuration.d.ts',
+]
+
+const TEST_FILES = [
+  '**/*.{test,spec}.{ts,tsx,js,jsx,mts,mjs}',
+  '**/test/**/*.{ts,tsx,js,jsx,mts,mjs}',
+  '**/tests/**/*.{ts,tsx,js,jsx,mts,mjs}',
+]
+
+/** Code fences in markdown are illustrative, so most style and safety rules do not apply. */
+const MARKDOWN_CODE_FILES = ['**/*.md/**']
+
+/** Example apps pin real versions on purpose, so workspace catalog rules do not apply. */
+const EXAMPLE_MANIFESTS = ['examples/**/package.json']
+
+/**
+ * Shared flat config blocks.
+ *
+ * Spread these after the preset whose rules they turn off.
+ */
+export function base(options: BaseOptions = {}): Linter.Config[] {
+  const { type = 'lib', ignores = [] } = options
+
+  const rules: Linter.RulesRecord = {
+    'no-use-before-define': 'off',
+    'ts/no-use-before-define': 'off',
+    'node/prefer-global/process': 'off',
+    'node/prefer-global/buffer': 'off',
+  }
+  if (type === 'lib') {
+    rules['ts/explicit-function-return-type'] = 'off'
+  }
+
+  return [
+    {
+      name: 'harlanzw/base/ignores',
+      ignores: [...BASE_IGNORES, ...ignores],
+    },
+    {
+      name: 'harlanzw/base/rules',
+      rules,
+    },
+    {
+      name: 'harlanzw/base/tests',
+      files: TEST_FILES,
+      rules: {
+        'no-console': 'off',
+        'ts/no-unsafe-function-type': 'off',
+        'antfu/no-top-level-await': 'off',
+        'e18e/prefer-static-regex': 'off',
+      },
+    },
+    {
+      name: 'harlanzw/base/markdown',
+      files: MARKDOWN_CODE_FILES,
+      rules: {
+        'no-console': 'off',
+        'no-tabs': 'off',
+        'style/no-tabs': 'off',
+        'style/max-statements-per-line': 'off',
+        'e18e/prefer-static-regex': 'off',
+        'unused-imports/no-unused-vars': 'off',
+      },
+    },
+    {
+      name: 'harlanzw/base/examples',
+      files: EXAMPLE_MANIFESTS,
+      rules: {
+        'pnpm/json-enforce-catalog': 'off',
+        'pnpm/json-valid-catalog': 'off',
+        'pnpm/json-prefer-workspace-settings': 'off',
+      },
+    },
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import type { ESLint, Linter } from 'eslint'
+import type { BaseOptions } from './base'
 import type { LinkRuleOptions } from './link-utils'
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import { version } from '../package.json'
+import { base } from './base'
 import { PROMPT_FILES, SKILL_FILES } from './prompt/constants'
 import { CONTENT_FILES, NUXT_CONTENT_FILES } from './prompt/deslop-constants'
 import { PromptLanguage } from './prompt/language'
@@ -402,6 +404,14 @@ plugin.configs!.recommended = [
 
 // Factory options
 export interface HarlanzwOptions {
+  /**
+   * Shared override blocks: ignores, node globals, test and markdown relaxations.
+   *
+   * Opt in with `true` for the defaults, or pass {@link BaseOptions}.
+   *
+   * @default false
+   */
+  base?: boolean | BaseOptions
   link?: boolean | LinkRuleOptions & { requireTrailingSlash?: boolean }
   nuxt?: boolean
   vue?: boolean
@@ -464,6 +474,10 @@ function buildLinkRules(linkOpts: LinkRuleOptions & { requireTrailingSlash?: boo
 function harlanzw(options: HarlanzwOptions = {}, ...extraConfigs: Linter.Config[]): Linter.Config[] {
   const detected = detectFramework()
   const configs: Linter.Config[] = []
+
+  if (options.base) {
+    configs.push(...base(typeof options.base === 'object' ? options.base : {}))
+  }
 
   if (options.link !== false) {
     const linkOpts = typeof options.link === 'object' ? options.link : {}
@@ -534,6 +548,8 @@ interface HarlanzwFactory {
 
 const harlanzwWithPlugin: HarlanzwFactory = Object.assign(harlanzw, { plugin, detectFramework })
 
+export type { BaseOptions } from './base'
+export { base } from './base'
 export { harlanzwWithPlugin as harlanzw, plugin }
 export default harlanzwWithPlugin
 


### PR DESCRIPTION
### Description

Every repo I own ends up with the same block of `off` rules pasted into its eslint config: `node/prefer-global/process`, `node/prefer-global/buffer`, `no-use-before-define`, a test-file relaxation, a markdown-fence relaxation, and the pnpm catalog rules switched off for `examples/`. I counted the node globals block in 23 repos and `no-use-before-define` in 20, all drifted apart in small ways (`.claude` vs `.claude/**`, `examples/*` vs `examples/**`, three different test glob spellings).

`base()` moves those blocks in here, either as `harlanzw({ base: true })` or spread on their own with `...base()`. `type` defaults to `lib` and also drops `ts/explicit-function-return-type`; `ignores` appends to the shared set.

The part worth a reviewer's attention: every rule in these blocks is `off`, and flat config quietly accepts an `off` entry for a rule whose plugin was never registered, while an `error` entry throws. That is what lets the blocks carry no dependency on `@antfu/eslint-config` and still work under `@nuxt/eslint` or bare ESLint. If ESLint ever tightens that, this breaks for anyone not running antfu.

This repo now uses it, so its own config went from 45 lines to 22.

Second commit is a docs pass that was sitting on the same branch: `CLAUDE.md` is cut back to what isn't already derivable from the code, and the `vue-eslint-parser` patterns move out to `docs/vue-ast-rules.md`.

### Additional context

Loose ends I did not take:

- `base` is opt in, so the ~18 repos already calling `harlanzw()` are untouched. Worth making it the default in a major?
- It turns off `ts/no-use-before-define` alongside the core rule. I diffed the resolved config against zhead with `--print-config` and that was the only severity change out of 375 rules, but repos that deliberately kept the TS variant on would lose it.
- The `examples/**/package.json` block is not exercised by any repo I tried it against.
- The ignore set includes `playground/**` and `**/fixtures/**`, which matches what 8 of the configs did by hand. Sites that intentionally lint their playground would need to add it back.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).