### PR TITLE
fix: stop base ignores hiding agent files from the prompt rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ export default antfu(
 )
 ```
 
-`type` defaults to `'lib'`, which also turns off `ts/explicit-function-return-type`. `ignores` appends to the shared set.
+`type` defaults to `'lib'`, which also turns off `ts/explicit-function-return-type`. `ignores` appends to the shared set. Every shared ignore glob is recursive, so nested playgrounds and fixtures in a monorepo are covered.
+
+`agentFiles` decides what happens to `CLAUDE.md`, `AGENTS.md`, `.claude`, and `.cursor`. It defaults to `'ignore'`, keeping them out of the lint run. A global ignore beats any `files`-scoped config, so `harlanzw()` switches it to `'lint'` whenever its prompt config is enabled, otherwise the prompt rules would never see those files. Set it explicitly to override that.
 
 Every rule in these blocks is set to `off`, and flat config ignores an `off` entry for a rule whose plugin is absent. So the blocks are safe with any preset, and need no dependency on `@antfu/eslint-config`.
 
@@ -172,7 +174,7 @@ Contents:
 
 | Block | Applies to | Turns off |
 | --- | --- | --- |
-| `harlanzw/base/ignores` | global | `CLAUDE.md`, `AGENTS.md`, `.claude`, `.cursor`, `.data`, fixtures, `playground`, `worker-configuration.d.ts` |
+| `harlanzw/base/ignores` | global | `.data`, fixtures, `playground`, `worker-configuration.d.ts`, plus `CLAUDE.md`, `AGENTS.md`, `.claude`, `.cursor` when `agentFiles` is `'ignore'` |
 | `harlanzw/base/rules` | all files | `no-use-before-define`, `node/prefer-global/process`, `node/prefer-global/buffer` (+ `ts/explicit-function-return-type` for libs) |
 | `harlanzw/base/tests` | test files | `no-console`, `ts/no-unsafe-function-type`, `antfu/no-top-level-await`, `e18e/prefer-static-regex` |
 | `harlanzw/base/markdown` | `**/*.md/**` | `no-console`, tabs, `style/max-statements-per-line`, `e18e/prefer-static-regex`, unused imports |

--- a/src/base.test.ts
+++ b/src/base.test.ts
@@ -59,11 +59,35 @@ describe('base', () => {
       .toHaveProperty('ts/explicit-function-return-type')
   })
 
+  it('ignores agent files by default', () => {
+    const ignores = blockNamed(base(), 'harlanzw/base/ignores').ignores
+
+    expect(ignores).toContain('**/CLAUDE.md')
+    expect(ignores).toContain('**/.claude/**')
+  })
+
+  it('leaves agent files alone when something else lints them', () => {
+    const ignores = blockNamed(base({ agentFiles: 'lint' }), 'harlanzw/base/ignores').ignores
+
+    expect(ignores).not.toContain('**/CLAUDE.md')
+    expect(ignores).not.toContain('**/.claude/**')
+    // The non-agent entries are unaffected either way.
+    expect(ignores).toContain('**/playground/**')
+  })
+
+  it('ignores nested playgrounds, fixtures, and data dirs', () => {
+    const ignores = blockNamed(base(), 'harlanzw/base/ignores').ignores as string[]
+
+    for (const glob of ignores) {
+      expect(glob.startsWith('**/'), `${glob} is root anchored`).toBe(true)
+    }
+  })
+
   it('appends extra ignores to the shared set', () => {
     const ignores = blockNamed(base({ ignores: ['docs/**'] }), 'harlanzw/base/ignores').ignores
 
     expect(ignores).toContain('docs/**')
-    expect(ignores).toContain('playground/**')
+    expect(ignores).toContain('**/playground/**')
   })
 })
 
@@ -83,6 +107,20 @@ describe('harlanzw({ base })', () => {
     expect(names[0]).toBe('harlanzw/base/ignores')
     expect(names).toContain('harlanzw/nuxt')
     expect(names.indexOf('harlanzw/base/examples')).toBeLessThan(names.indexOf('harlanzw/nuxt'))
+  })
+
+  it('keeps agent files lintable when the prompt config is on', () => {
+    const withPrompt = harlanzw({ ...off, base: true, prompt: true })
+    const withoutPrompt = harlanzw({ ...off, base: true, prompt: false })
+
+    expect(blockNamed(withPrompt, 'harlanzw/base/ignores').ignores).not.toContain('**/CLAUDE.md')
+    expect(blockNamed(withoutPrompt, 'harlanzw/base/ignores').ignores).toContain('**/CLAUDE.md')
+  })
+
+  it('lets an explicit agentFiles choice win over the prompt default', () => {
+    const configs = harlanzw({ ...off, base: { agentFiles: 'ignore' }, prompt: true })
+
+    expect(blockNamed(configs, 'harlanzw/base/ignores').ignores).toContain('**/CLAUDE.md')
   })
 
   it('forwards base options', () => {

--- a/src/base.ts
+++ b/src/base.ts
@@ -18,18 +18,36 @@ export interface BaseOptions {
    * Paths to ignore on top of the shared ignore set.
    */
   ignores?: string[]
+  /**
+   * What to do with `CLAUDE.md`, `AGENTS.md`, and the agent tool directories.
+   *
+   * `ignore` keeps them out of the lint run entirely, which is what most repos
+   * did by hand. `lint` leaves them for the prompt configs to pick up.
+   *
+   * A global `ignores` block beats any `files`-scoped config, so ignoring these
+   * here would silently stop the prompt rules from ever seeing them.
+   * {@link harlanzw} passes `lint` whenever its prompt config is enabled.
+   *
+   * @default 'ignore'
+   */
+  agentFiles?: 'ignore' | 'lint'
 }
 
-/** Ignored everywhere. Agent files are linted by the prompt configs instead. */
+// Globs are recursive: monorepo packages carry their own playground, fixtures,
+// and agent files, and a root-anchored glob misses every nested copy.
+const AGENT_IGNORES = [
+  '**/CLAUDE.md',
+  '**/AGENTS.md',
+  '**/.claude/**',
+  '**/.cursor/**',
+]
+
+/** Ignored everywhere, whatever the agent file handling is. */
 const BASE_IGNORES = [
-  'CLAUDE.md',
-  'AGENTS.md',
-  '.claude/**',
-  '.cursor/**',
-  '.data/**',
+  '**/.data/**',
   '**/test/fixtures/**',
   '**/fixtures/**',
-  'playground/**',
+  '**/playground/**',
   '**/worker-configuration.d.ts',
 ]
 
@@ -51,7 +69,7 @@ const EXAMPLE_MANIFESTS = ['examples/**/package.json']
  * Spread these after the preset whose rules they turn off.
  */
 export function base(options: BaseOptions = {}): Linter.Config[] {
-  const { type = 'lib', ignores = [] } = options
+  const { type = 'lib', ignores = [], agentFiles = 'ignore' } = options
 
   const rules: Linter.RulesRecord = {
     'no-use-before-define': 'off',
@@ -66,7 +84,11 @@ export function base(options: BaseOptions = {}): Linter.Config[] {
   return [
     {
       name: 'harlanzw/base/ignores',
-      ignores: [...BASE_IGNORES, ...ignores],
+      ignores: [
+        ...BASE_IGNORES,
+        ...(agentFiles === 'ignore' ? AGENT_IGNORES : []),
+        ...ignores,
+      ],
     },
     {
       name: 'harlanzw/base/rules',

--- a/src/index.ts
+++ b/src/index.ts
@@ -481,9 +481,16 @@ function buildLinkRules(linkOpts: LinkRuleOptions & { requireTrailingSlash?: boo
 function harlanzw(options: HarlanzwOptions = {}, ...extraConfigs: Linter.Config[]): Linter.Config[] {
   const detected = detectFramework()
   const configs: Linter.Config[] = []
+  const enablePrompt = options.prompt ?? detected.prompt
 
   if (options.base) {
-    configs.push(...base(typeof options.base === 'object' ? options.base : {}))
+    const baseOpts = typeof options.base === 'object' ? options.base : {}
+    configs.push(...base({
+      // A global ignore beats the prompt configs' `files`, so agent files stay
+      // in the lint run whenever the prompt rules are there to lint them.
+      agentFiles: enablePrompt ? 'lint' : 'ignore',
+      ...baseOpts,
+    }))
   }
 
   if (options.link !== false) {
@@ -497,7 +504,6 @@ function harlanzw(options: HarlanzwOptions = {}, ...extraConfigs: Linter.Config[
     })
   }
 
-  const enablePrompt = options.prompt ?? detected.prompt
   if (enablePrompt) {
     const preset = typeof options.prompt === 'string' ? options.prompt : 'recommended'
     configs.push(...plugin.configs![`prompt:${preset}`] as Linter.Config[])


### PR DESCRIPTION
### Description

Two bugs in `base()`, both found while adopting it in zhead.dev and nuxt-seo.

The first is a silent coverage loss. `harlanzw/base/ignores` is a global ignores block, and a global ignore beats any `files`-scoped config, so ignoring `CLAUDE.md` and `.claude/**` there stopped the prompt configs in the same `harlanzw()` call from ever linting them. No error, no warning, the files just quietly left the run. zhead.dev's file set went 184 to 183 and the only thing dropped was `CLAUDE.md`.

`agentFiles` now controls this, defaulting to `'ignore'` (what most repos did by hand). `harlanzw()` passes `'lint'` whenever its prompt config is on, and an explicit option still wins:

```js
harlanzw({ base: true, prompt: true })                      // agent files linted
harlanzw({ base: true, prompt: false })                     // agent files ignored
harlanzw({ base: { agentFiles: 'ignore' }, prompt: true })  // ignored, explicitly
```

The second is that `playground/**` and `.data/**` were root anchored. nuxt-seo has `playground/`, `packages/shared/playground/` and `packages/nuxt-seo/playground/`, so the glob matched one of three. Every shared ignore glob is now `**/`-prefixed, matching how `**/test/fixtures/**` was already written.

### Additional context

Loose ends:

- The recursive globs mean `base()` now ignores strictly more than before. A repo that deliberately lints a nested playground has to stop using the shared ignore set for it, and I have not checked all nine sites for that.
- `agentFiles` keys off whether the *prompt* config is enabled, not the content config. A repo running only `content` on agent markdown would still see them ignored. That felt too speculative to build for.
- The unit tests assert the resolved ignore list; I also checked the real behaviour through the `ESLint` class on a `CLAUDE.md` with an unclosed fence, and `prompt-unclosed-code-fence` fires with prompt on while the file is ignored with prompt off.

Needs a patch release before the remaining 14 repos adopt `base`, since both bugs bite hardest in monorepos.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
