### PR TITLE
feat: let base() hand its ignore set back to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ export default antfu(
 
 `type` defaults to `'lib'`, which also turns off `ts/explicit-function-return-type`. `ignores` appends to the shared set. Every shared ignore glob is recursive, so nested playgrounds and fixtures in a monorepo are covered.
 
+Pass `ignores: false` to drop the shared ignore block and declare your own. A global ignore cannot be undone by a later config, so this is the only way to keep linting something the shared set covers, such as a playground you lint on purpose. The rule blocks still apply.
+
 `agentFiles` decides what happens to `CLAUDE.md`, `AGENTS.md`, `.claude`, and `.cursor`. It defaults to `'ignore'`, keeping them out of the lint run. A global ignore beats any `files`-scoped config, so `harlanzw()` switches it to `'lint'` whenever its prompt config is enabled, otherwise the prompt rules would never see those files. Set it explicitly to override that.
 
 Every rule in these blocks is set to `off`, and flat config ignores an `off` entry for a rule whose plugin is absent. So the blocks are safe with any preset, and need no dependency on `@antfu/eslint-config`.

--- a/src/base.test.ts
+++ b/src/base.test.ts
@@ -83,6 +83,30 @@ describe('base', () => {
     }
   })
 
+  it('drops the ignore block entirely when the repo wants to own it', () => {
+    const configs = base({ ignores: false })
+
+    expect(configs.find(c => c.name === 'harlanzw/base/ignores')).toBeUndefined()
+    // The rule blocks still apply.
+    expect(configs.map(c => c.name)).toContain('harlanzw/base/rules')
+  })
+
+  it('keeps a file lintable when the shared ignores are dropped', () => {
+    const configs = [
+      { files: ['**/*.js'], rules: { 'no-console': 'error' } } as LinterTypes.Config,
+      ...base({ ignores: false }),
+    ]
+
+    const shared = [
+      { files: ['**/*.js'], rules: { 'no-console': 'error' } } as LinterTypes.Config,
+      ...base(),
+    ]
+
+    // `playground/**` is in the shared set, so the rule only reaches it without.
+    expect(lint('console.log(1)\n', shared, 'playground/a.js')).not.toContain('no-console')
+    expect(lint('console.log(1)\n', configs, 'playground/a.js')).toEqual(['no-console'])
+  })
+
   it('appends extra ignores to the shared set', () => {
     const ignores = blockNamed(base({ ignores: ['docs/**'] }), 'harlanzw/base/ignores').ignores
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -16,8 +16,12 @@ export interface BaseOptions {
   type?: 'lib' | 'app'
   /**
    * Paths to ignore on top of the shared ignore set.
+   *
+   * `false` drops the shared ignore block, leaving the repo to declare its own.
+   * A global ignore cannot be undone by a later config, so this is the only way
+   * to keep linting something the shared set covers, such as a playground.
    */
-  ignores?: string[]
+  ignores?: string[] | false
   /**
    * What to do with `CLAUDE.md`, `AGENTS.md`, and the agent tool directories.
    *
@@ -82,14 +86,16 @@ export function base(options: BaseOptions = {}): Linter.Config[] {
   }
 
   return [
-    {
-      name: 'harlanzw/base/ignores',
-      ignores: [
-        ...BASE_IGNORES,
-        ...(agentFiles === 'ignore' ? AGENT_IGNORES : []),
-        ...ignores,
-      ],
-    },
+    ...(ignores === false
+      ? []
+      : [{
+          name: 'harlanzw/base/ignores',
+          ignores: [
+            ...BASE_IGNORES,
+            ...(agentFiles === 'ignore' ? AGENT_IGNORES : []),
+            ...ignores,
+          ],
+        }]),
     {
       name: 'harlanzw/base/rules',
       rules,


### PR DESCRIPTION
### Description

og-image lints its `playground/**` and `test/fixtures/**` on purpose. Adopting `base()` took its lint run from 702 files to 382 without a word, because the shared ignore set covers both. A global ignore cannot be undone by a later config, so the only escape was to stop using `base()` at all.

`ignores: false` drops the shared ignore block and keeps everything else:

```js
harlanzw({ base: { ignores: false }, nuxt: true })
```

The files were clean in og-image's case, so nothing was hiding behind the drop, but the same silent narrowing would land in any repo that lints a directory the shared set covers.

### Additional context

- The two tests assert both directions, since `Linter.verify` does honour global ignores: with the shared set the file reports the ignore message, with `ignores: false` the rule reaches it.
- This makes the option do double duty as a partial escape hatch: a repo that wants most of the shared set minus one entry has to restate the whole list. Enumerating the groups (`ignores: { playground: false }`) would be finer grained, and I would rather see whether anyone actually needs that first.
- Still unsolved from the fan-out: `.playground/**` with a leading dot is not matched by `**/playground/**`, so nuxt-site-config keeps that ignore inline. Adding the dotted variant to the shared set felt like guessing at a convention that only one repo uses.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
