### PR TITLE
fix(prefer-satisfies): skip lookup maps read by a computed key

### DIFF
--- a/src/rules/prefer-satisfies.md
+++ b/src/rules/prefer-satisfies.md
@@ -39,15 +39,16 @@ The annotation must erase a known key set, and the object must be safe to freeze
 - the value type `V` is not `any` or `unknown`
 - the initialiser is a non-empty object literal with no spread elements
 - the variable is never written to afterwards
+- the variable is never read with a computed non-literal key
 
 ## Examples
 
 Incorrect:
 
 ```ts
-const XML_ENTITIES: Record<string, string> = {
-  amp: '&',
-  lt: '<',
+const HANDLERS: Record<string, Handler> = {
+  start: startHandler,
+  stop: stopHandler,
 }
 
 const products: Record<number, Product> = {
@@ -62,10 +63,10 @@ const TITLES: Readonly<Record<string, string>> = {
 Correct:
 
 ```ts
-const XML_ENTITIES = {
-  amp: '&',
-  lt: '<',
-} satisfies Record<string, string>
+const HANDLERS = {
+  start: startHandler,
+  stop: stopHandler,
+} satisfies Record<string, Handler>
 ```
 
 ## When Not To Use It
@@ -87,6 +88,23 @@ A mutable map needs the open key type, because `satisfies` would reject any new 
 const counts: Record<string, number> = { total: 0 }
 counts[key] = 1
 ```
+
+A lookup map read by a computed key needs the open key type. Narrowing it makes every
+read an implicit `any`, so `satisfies` would trade this warning for a type error:
+
+```ts
+const XML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+}
+
+export function decode(name: string) {
+  return XML_ENTITIES[name]
+}
+```
+
+A literal key names one member, so it does not exempt the map. `XML_ENTITIES['amp']`
+is still reported.
 
 A bag of `unknown` or `any` values carries no evidence worth preserving:
 

--- a/src/rules/prefer-satisfies.test.ts
+++ b/src/rules/prefer-satisfies.test.ts
@@ -115,8 +115,43 @@ run({
         mode: 'strict',
       }
     `,
+    // read by a computed key, so narrowing would make the read an implicit any
+    $`
+      const icons: Record<string, string> = {
+        vue: 'i-logos-vue',
+      }
+      export function iconFor(name: string) {
+        return icons[name]
+      }
+    `,
+    // the computed key can be any expression
+    $`
+      const weights: Record<string, number> = {
+        bold: 700,
+      }
+      export function weightFor(prefix: string) {
+        return weights['font-' + prefix]
+      }
+    `,
+    // indexed inside a callback over its own keys
+    $`
+      const styles: Record<string, string> = {
+        color: 'red',
+      }
+      export const pairs = Object.keys(styles).map(k => [k, styles[k]])
+    `,
   ],
   invalid: [
+    // a literal computed key names one key, so the key set can still be narrowed
+    {
+      code: $`
+        const handlers: Record<string, Handler> = {
+          start: startHandler,
+        }
+        export const first = handlers['start']
+      `,
+      errors: [{ messageId: 'preferSatisfies' }],
+    },
     // Record<string, V>
     {
       code: $`
@@ -194,14 +229,14 @@ run({
       `,
       errors: [{ messageId: 'preferSatisfies' }],
     },
-    // read-only usage elsewhere does not exempt it
+    // read-only usage by a static key does not exempt it
     {
       code: $`
         const labels: Record<string, string> = {
           start: 'Start',
         }
-        export function label(key: string) {
-          return labels[key]
+        export function label() {
+          return labels.start
         }
       `,
       errors: [{ messageId: 'preferSatisfies' }],

--- a/src/rules/prefer-satisfies.ts
+++ b/src/rules/prefer-satisfies.ts
@@ -69,6 +69,22 @@ function hasStaticKeys(node: TSESTree.ObjectExpression): boolean {
 }
 
 /**
+ * A lookup map read by a computed key needs the wide annotation to stay indexable.
+ * Narrowing it to its literal keys makes every `map[someString]` an implicit `any`,
+ * so `satisfies` would trade a lint warning for a type error.
+ */
+function isDynamicallyIndexed(references: TSESTree.Identifier[]): boolean {
+  return references.some((id) => {
+    const parent = id.parent
+    if (parent?.type !== 'MemberExpression' || parent.object !== id || !parent.computed)
+      return false
+
+    // `x['a']` and `x[0]` name one key, so the key set can still be narrowed.
+    return parent.property.type !== 'Literal'
+  })
+}
+
+/**
  * `satisfies` freezes the key set, so an object that is written to after
  * declaration genuinely needs the wide annotation.
  */
@@ -147,7 +163,7 @@ export default createEslintRule<Options, MessageIds>({
           .filter(ref => ref.identifier !== node.id)
           .map(ref => ref.identifier as TSESTree.Identifier)
 
-        if (isMutated(references))
+        if (isMutated(references) || isDynamicallyIndexed(references))
           return
 
         const annotationText = sourceCode.getText(annotation)


### PR DESCRIPTION
## Problem

`satisfies` narrows an object to its literal keys. A map read with a computed
non-literal key then has no index signature, so the read becomes an implicit
`any` and TS7053 fires:

```ts
const icons: Record<string, string> = { vue: 'i-logos-vue' }
export function iconFor(name: string) {
  return icons[name] // fine today
}
```

Take the suggestion and `icons[name]` stops compiling. The rule was trading a
warning for a type error.

## Evidence

Adopting `base()` across 6 repos surfaced 43 `prefer-satisfies` warnings. I
applied all 43 suggestions and ran typecheck:

| repo | edits | TS7053 after |
| --- | --- | --- |
| og-image | 25 | 18 |
| zhead.dev | 3 | 5 |
| nuxt-seo | 7 | 2 |
| sitemap | 2 | 2 |
| nuxt-seo-utils | 2 | 1 |
| nuxt-schema-org | 4 | 0 |

Every failure was a lookup map. All 43 edits are reverted.

## Fix

Skip the report when any reference reads the variable through a computed
non-literal key. A literal key (`icons['vue']`) names one member, so it does not
exempt the map and stays reported.

Re-running the rule over the 10 source files that broke typecheck now reports 0.

One existing invalid case asserted the opposite (`labels[key]` should report).
That case encoded the bug, so it is replaced with the static-key equivalent, and
three valid cases cover the new exemption.

`pnpm test` 1033 pass, `pnpm typecheck` clean.
