### PR TITLE
fix(prefer-satisfies): skip lookup maps read from a Vue template

### DIFF
--- a/check-vue.tmp.ts
+++ b/check-vue.tmp.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import process from 'node:process'
+import { Linter } from 'eslint'
+import * as vueParser from 'vue-eslint-parser'
+import * as tsParser from '@typescript-eslint/parser'
+import rule from './src/rules/prefer-satisfies'
+const linter = new Linter()
+for (const file of process.argv.slice(2)) {
+  const msgs = linter.verify(readFileSync(file, 'utf8'), [{
+    files: ['**/*.vue'],
+    languageOptions: { parser: vueParser as any, parserOptions: { parser: tsParser as any, ecmaVersion: 'latest', sourceType: 'module' } },
+    plugins: { h: { rules: { s: rule as any } } },
+    rules: { 'h/s': 'warn' },
+  }], file)
+  console.log(`${msgs.filter(m => m.ruleId === 'h/s').length}  ${file.split('/').slice(-1)[0]}`)
+}

--- a/src/rules/prefer-satisfies.md
+++ b/src/rules/prefer-satisfies.md
@@ -39,7 +39,7 @@ The annotation must erase a known key set, and the object must be safe to freeze
 - the value type `V` is not `any` or `unknown`
 - the initialiser is a non-empty object literal with no spread elements
 - the variable is never written to afterwards
-- the variable is never read with a computed non-literal key
+- the variable is never read with a computed non-literal key, in the script or in a Vue template
 
 ## Examples
 
@@ -105,6 +105,26 @@ export function decode(name: string) {
 
 A literal key names one member, so it does not exempt the map. `XML_ENTITIES['amp']`
 is still reported.
+
+The same applies to a Vue template, whose expressions the script's scope analysis
+never sees:
+
+```vue
+<script setup lang="ts">
+const defaultIcons: Record<string, string> = {
+  info: 'i-carbon-information',
+}
+</script>
+
+<template>
+  <UIcon :name="defaultIcons[variant]" />
+</template>
+```
+
+Two blind spots remain, because both need type information the rule does not have.
+A map that is exported and indexed in another file, and a map that is spread into
+another object which is then indexed, are still reported. Check the suggestion
+before taking it.
 
 A bag of `unknown` or `any` values carries no evidence worth preserving:
 

--- a/src/rules/prefer-satisfies.test.ts
+++ b/src/rules/prefer-satisfies.test.ts
@@ -1,6 +1,6 @@
 import type { Linter } from 'eslint'
 import { unindent as $ } from 'eslint-vitest-rule-tester'
-import { run } from './_test'
+import { run, runVue } from './_test'
 import rule, { RULE_NAME } from './prefer-satisfies'
 
 /** Applies a report's single suggestion to `code` so the rewrite can be asserted. */
@@ -238,6 +238,63 @@ run({
         export function label() {
           return labels.start
         }
+      `,
+      errors: [{ messageId: 'preferSatisfies' }],
+    },
+  ],
+})
+
+runVue({
+  name: `${RULE_NAME} (vue)`,
+  rule,
+  valid: [
+    // read by a computed key in the template, which the script scope cannot see
+    {
+      filename: 'test.vue',
+      code: $`
+        <script setup lang="ts">
+        const defaultIcons: Record<string, string> = {
+          info: 'i-carbon-information',
+        }
+        const props = defineProps<{ variant: string }>()
+        </script>
+
+        <template>
+          <UIcon :name="defaultIcons[props.variant]" />
+        </template>
+      `,
+    },
+    // optional chaining off the computed read still counts
+    {
+      filename: 'test.vue',
+      code: $`
+        <script setup lang="ts">
+        const labels: Record<string, { text: string }> = {
+          rel: { text: 'Rel' },
+        }
+        const props = defineProps<{ rel: string }>()
+        </script>
+
+        <template>
+          <span>{{ labels[props.rel]?.text }}</span>
+        </template>
+      `,
+    },
+  ],
+  invalid: [
+    // only ever read by a static key, in script and template alike
+    {
+      filename: 'test.vue',
+      code: $`
+        <script setup lang="ts">
+        const defaultIcons: Record<string, string> = {
+          info: 'i-carbon-information',
+        }
+        </script>
+
+        <template>
+          <UIcon :name="defaultIcons.info" />
+        </template>
       `,
       errors: [{ messageId: 'preferSatisfies' }],
     },

--- a/src/rules/prefer-satisfies.ts
+++ b/src/rules/prefer-satisfies.ts
@@ -85,6 +85,51 @@ function isDynamicallyIndexed(references: TSESTree.Identifier[]): boolean {
 }
 
 /**
+ * Vue template expressions are parsed into a separate AST, so the script's scope
+ * analysis never sees `<UIcon :name="icons[label]" />`. Collect the names read
+ * with a computed key straight from the template body instead.
+ */
+function templateComputedReads(sourceCode: any): Set<string> {
+  const names = new Set<string>()
+  const body = sourceCode?.ast?.templateBody
+  if (!body)
+    return names
+
+  const seen = new Set<object>()
+  const stack: any[] = [body]
+  while (stack.length) {
+    const node = stack.pop()
+    if (!node || typeof node !== 'object' || seen.has(node))
+      continue
+    seen.add(node)
+
+    if (Array.isArray(node)) {
+      stack.push(...node)
+      continue
+    }
+
+    if (
+      node.type === 'MemberExpression'
+      && node.computed
+      && node.object?.type === 'Identifier'
+      && node.property?.type !== 'Literal'
+    ) {
+      names.add(node.object.name)
+    }
+
+    for (const key of Object.keys(node)) {
+      // `parent` walks back up and would loop forever.
+      if (key === 'parent')
+        continue
+      const value = node[key]
+      if (value && typeof value === 'object')
+        stack.push(value)
+    }
+  }
+  return names
+}
+
+/**
  * `satisfies` freezes the key set, so an object that is written to after
  * declaration genuinely needs the wide annotation.
  */
@@ -138,6 +183,8 @@ export default createEslintRule<Options, MessageIds>({
   defaultOptions: [],
   create: (context) => {
     const sourceCode = context.sourceCode ?? context.getSourceCode()
+    // The template AST is fixed for the file, so walk it at most once.
+    let templateReads: Set<string> | null = null
 
     return {
       VariableDeclarator(node) {
@@ -164,6 +211,10 @@ export default createEslintRule<Options, MessageIds>({
           .map(ref => ref.identifier as TSESTree.Identifier)
 
         if (isMutated(references) || isDynamicallyIndexed(references))
+          return
+
+        templateReads ??= templateComputedReads(sourceCode)
+        if (templateReads.has(node.id.name))
           return
 
         const annotationText = sourceCode.getText(annotation)


### PR DESCRIPTION
Follow-up to #14, which fixed the same bug for script references.

## Problem

Vue template expressions are parsed into a separate AST hanging off
`Program.templateBody`. The script's scope analysis never sees them, so this map
was still reported:

```vue
<script setup lang="ts">
const defaultIcons: Record<string, string> = {
  info: 'i-carbon-information',
}
</script>

<template>
  <UIcon :name="defaultIcons[variant]" />
</template>
```

Take the suggestion and the template read becomes an implicit `any`.

## Fix

Walk `sourceCode.ast.templateBody` for computed non-literal reads and skip those
names, the same exemption 0.19.1 applies to script references. The walk is done
once per file and only when a candidate is found. A static template read
(`defaultIcons.info`) still reports.

## Evidence

Four real components across the adoption PRs, each compared against 0.19.1:

| file | 0.19.1 | this PR |
| --- | --- | --- |
| zhead.dev `Collections.vue` | 1 | 0 |
| og-image `devtools/pages/og-image/index.vue` | 1 | 0 |
| nuxt-seo `DevtoolsAlert.vue` | 1 | 0 |
| nuxt-seo-utils `identity.vue` | 1 | 0 |

All four do a computed template read: `collectionIcons[snippet.label]`,
`defaultIcons[variant]`, `iconRelLabels[rel]`. Two of them sit in `devtools/`
folders that their repo's typecheck does not cover, so the breakage would not
have shown up as a TS error there, only in an editor.

## Known limits, now documented

Two classes are still reported, because both need type information:

- a map that is exported and indexed in another file (og-image `emoji-names-minimal.ts`)
- a map spread into another object which is then indexed (og-image `styleDirectives.ts`)

`pnpm test` 1036 pass, `pnpm typecheck` clean.
