### PR TITLE
feat(base): always ignore .claude, split from the path ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ export default antfu(
 
 Pass `ignores: false` to drop the shared ignore block and declare your own. A global ignore cannot be undone by a later config, so this is the only way to keep linting something the shared set covers, such as a playground you lint on purpose. The rule blocks still apply.
 
-`agentFiles` decides what happens to `CLAUDE.md`, `AGENTS.md`, `.claude`, and `.cursor`. It defaults to `'ignore'`, keeping them out of the lint run. A global ignore beats any `files`-scoped config, so `harlanzw()` switches it to `'lint'` whenever its prompt config is enabled, otherwise the prompt rules would never see those files. Set it explicitly to override that.
+`agentFiles` decides what happens to the prompts you wrote: `CLAUDE.md`, `AGENTS.md`, and `.cursor`. It defaults to `'ignore'`, keeping them out of the lint run. A global ignore beats any `files`-scoped config, so `harlanzw()` switches it to `'lint'` whenever its prompt config is enabled, otherwise the prompt rules would never see those files. Set it explicitly to override that.
+
+The `.claude` directory is always ignored, whatever `agentFiles` says. Nothing in it is a prompt this repo wrote: its skills are upstream package docs installed by skilld, its context is generated notes and job state, and agents drop whole repo checkouts in there. It also sits in its own block, so `ignores: false` does not hand it back.
 
 Every rule in these blocks is set to `off`, and flat config ignores an `off` entry for a rule whose plugin is absent. So the blocks are safe with any preset, and need no dependency on `@antfu/eslint-config`.
 
@@ -176,7 +178,8 @@ Contents:
 
 | Block | Applies to | Turns off |
 | --- | --- | --- |
-| `harlanzw/base/ignores` | global | `.data`, fixtures, `playground`, `worker-configuration.d.ts`, plus `CLAUDE.md`, `AGENTS.md`, `.claude`, `.cursor` when `agentFiles` is `'ignore'` |
+| `harlanzw/base/agent-ignores` | global | `.claude` always, plus `CLAUDE.md`, `AGENTS.md`, `.cursor` when `agentFiles` is `'ignore'` |
+| `harlanzw/base/ignores` | global | `.data`, fixtures, `playground`, `worker-configuration.d.ts`, plus your `ignores`. Dropped by `ignores: false` |
 | `harlanzw/base/rules` | all files | `no-use-before-define`, `node/prefer-global/process`, `node/prefer-global/buffer` (+ `ts/explicit-function-return-type` for libs) |
 | `harlanzw/base/tests` | test files | `no-console`, `ts/no-unsafe-function-type`, `antfu/no-top-level-await`, `e18e/prefer-static-regex` |
 | `harlanzw/base/markdown` | `**/*.md/**` | `no-console`, tabs, `style/max-statements-per-line`, `e18e/prefer-static-regex`, unused imports |

--- a/src/base.test.ts
+++ b/src/base.test.ts
@@ -59,20 +59,46 @@ describe('base', () => {
       .toHaveProperty('ts/explicit-function-return-type')
   })
 
-  it('ignores agent files by default', () => {
-    const ignores = blockNamed(base(), 'harlanzw/base/ignores').ignores
+  it('ignores the prompts you wrote by default', () => {
+    const ignores = blockNamed(base(), 'harlanzw/base/agent-ignores').ignores
 
     expect(ignores).toContain('**/CLAUDE.md')
-    expect(ignores).toContain('**/.claude/**')
+    expect(ignores).toContain('**/AGENTS.md')
   })
 
-  it('leaves agent files alone when something else lints them', () => {
-    const ignores = blockNamed(base({ agentFiles: 'lint' }), 'harlanzw/base/ignores').ignores
+  it('leaves the prompts you wrote alone when something else lints them', () => {
+    const ignores = blockNamed(base({ agentFiles: 'lint' }), 'harlanzw/base/agent-ignores').ignores
 
     expect(ignores).not.toContain('**/CLAUDE.md')
-    expect(ignores).not.toContain('**/.claude/**')
-    // The non-agent entries are unaffected either way.
-    expect(ignores).toContain('**/playground/**')
+    expect(ignores).not.toContain('**/AGENTS.md')
+  })
+
+  it('ignores the agent tool directory whatever agentFiles says', () => {
+    for (const agentFiles of ['ignore', 'lint'] as const) {
+      const ignores = blockNamed(base({ agentFiles }), 'harlanzw/base/agent-ignores').ignores
+
+      expect(ignores, agentFiles).toContain('**/.claude/**')
+    }
+  })
+
+  it('keeps a checked-out worktree under the agent directory out of the run', () => {
+    const configs = [
+      { files: ['**/*.ts'], rules: { 'no-console': 'error' } } as LinterTypes.Config,
+      ...base({ agentFiles: 'lint' }),
+    ]
+
+    const nested = '.claude/w/some-branch/src/index.ts'
+    expect(lint('console.log(1)\n', configs, nested)).not.toContain('no-console')
+  })
+
+  it('keeps a vendored skill out of the run while linting the repo CLAUDE.md', () => {
+    const configs = [
+      { files: ['**/*.md'], rules: { 'no-console': 'error' } } as LinterTypes.Config,
+      ...base({ agentFiles: 'lint' }),
+    ]
+
+    expect(lint('console.log(1)\n', configs, 'CLAUDE.md')).toEqual(['no-console'])
+    expect(lint('console.log(1)\n', configs, '.claude/skills/vitest-skilld/SKILL.md')).not.toContain('no-console')
   })
 
   it('ignores nested playgrounds, fixtures, and data dirs', () => {
@@ -83,12 +109,22 @@ describe('base', () => {
     }
   })
 
-  it('drops the ignore block entirely when the repo wants to own it', () => {
+  it('drops the path ignore block entirely when the repo wants to own it', () => {
     const configs = base({ ignores: false })
 
     expect(configs.find(c => c.name === 'harlanzw/base/ignores')).toBeUndefined()
     // The rule blocks still apply.
     expect(configs.map(c => c.name)).toContain('harlanzw/base/rules')
+  })
+
+  it('keeps vendored agent content ignored even when the repo owns its ignores', () => {
+    const configs = [
+      { files: ['**/*.md'], rules: { 'no-console': 'error' } } as LinterTypes.Config,
+      ...base({ ignores: false, agentFiles: 'lint' }),
+    ]
+
+    // A repo that lints its playground still has no reason to lint upstream docs.
+    expect(lint('console.log(1)\n', configs, '.claude/skills/vitest-skilld/SKILL.md')).not.toContain('no-console')
   })
 
   it('keeps a file lintable when the shared ignores are dropped', () => {
@@ -128,7 +164,7 @@ describe('harlanzw({ base })', () => {
     const configs = harlanzw({ ...off, base: true, nuxt: true })
     const names = configs.map(c => c.name)
 
-    expect(names[0]).toBe('harlanzw/base/ignores')
+    expect(names[0]).toBe('harlanzw/base/agent-ignores')
     expect(names).toContain('harlanzw/nuxt')
     expect(names.indexOf('harlanzw/base/examples')).toBeLessThan(names.indexOf('harlanzw/nuxt'))
   })
@@ -137,14 +173,14 @@ describe('harlanzw({ base })', () => {
     const withPrompt = harlanzw({ ...off, base: true, prompt: true })
     const withoutPrompt = harlanzw({ ...off, base: true, prompt: false })
 
-    expect(blockNamed(withPrompt, 'harlanzw/base/ignores').ignores).not.toContain('**/CLAUDE.md')
-    expect(blockNamed(withoutPrompt, 'harlanzw/base/ignores').ignores).toContain('**/CLAUDE.md')
+    expect(blockNamed(withPrompt, 'harlanzw/base/agent-ignores').ignores).not.toContain('**/CLAUDE.md')
+    expect(blockNamed(withoutPrompt, 'harlanzw/base/agent-ignores').ignores).toContain('**/CLAUDE.md')
   })
 
   it('lets an explicit agentFiles choice win over the prompt default', () => {
     const configs = harlanzw({ ...off, base: { agentFiles: 'ignore' }, prompt: true })
 
-    expect(blockNamed(configs, 'harlanzw/base/ignores').ignores).toContain('**/CLAUDE.md')
+    expect(blockNamed(configs, 'harlanzw/base/agent-ignores').ignores).toContain('**/CLAUDE.md')
   })
 
   it('forwards base options', () => {

--- a/src/base.ts
+++ b/src/base.ts
@@ -23,7 +23,7 @@ export interface BaseOptions {
    */
   ignores?: string[] | false
   /**
-   * What to do with `CLAUDE.md`, `AGENTS.md`, and the agent tool directories.
+   * What to do with the prompts you wrote: `CLAUDE.md`, `AGENTS.md`, `.cursor`.
    *
    * `ignore` keeps them out of the lint run entirely, which is what most repos
    * did by hand. `lint` leaves them for the prompt configs to pick up.
@@ -32,6 +32,9 @@ export interface BaseOptions {
    * here would silently stop the prompt rules from ever seeing them.
    * {@link harlanzw} passes `lint` whenever its prompt config is enabled.
    *
+   * Agent content nobody authored is ignored either way, see
+   * {@link GENERATED_AGENT_IGNORES}.
+   *
    * @default 'ignore'
    */
   agentFiles?: 'ignore' | 'lint'
@@ -39,11 +42,31 @@ export interface BaseOptions {
 
 // Globs are recursive: monorepo packages carry their own playground, fixtures,
 // and agent files, and a root-anchored glob misses every nested copy.
-const AGENT_IGNORES = [
+
+/** Prompts written in this repo. {@link BaseOptions.agentFiles} decides these. */
+const AUTHORED_AGENT_IGNORES = [
   '**/CLAUDE.md',
   '**/AGENTS.md',
-  '**/.claude/**',
   '**/.cursor/**',
+]
+
+/**
+ * The agent tool directory, which holds no prompt this repo wrote.
+ *
+ * Its skills are upstream package docs installed by skilld; the skills you write
+ * live in `skills/`. Its context is generated design notes and job state. It also
+ * picks up local machine state, and agents drop whole repo checkouts in there,
+ * which would pull thousands of files into the lint run.
+ *
+ * The set of things that land here keeps growing, so the whole directory goes,
+ * rather than a list that has to be chased. `CLAUDE.md` and `AGENTS.md` sit
+ * outside it and stay lintable, which is the point of splitting these apart.
+ *
+ * Ignored whatever `agentFiles` says, and kept out of the {@link BaseOptions.ignores}
+ * block so `ignores: false` does not hand it back.
+ */
+const GENERATED_AGENT_IGNORES = [
+  '**/.claude/**',
 ]
 
 /** Ignored everywhere, whatever the agent file handling is. */
@@ -86,15 +109,18 @@ export function base(options: BaseOptions = {}): Linter.Config[] {
   }
 
   return [
+    {
+      name: 'harlanzw/base/agent-ignores',
+      ignores: [
+        ...GENERATED_AGENT_IGNORES,
+        ...(agentFiles === 'ignore' ? AUTHORED_AGENT_IGNORES : []),
+      ],
+    },
     ...(ignores === false
       ? []
       : [{
           name: 'harlanzw/base/ignores',
-          ignores: [
-            ...BASE_IGNORES,
-            ...(agentFiles === 'ignore' ? AGENT_IGNORES : []),
-            ...ignores,
-          ],
+          ignores: [...BASE_IGNORES, ...ignores],
         }]),
     {
       name: 'harlanzw/base/rules',


### PR DESCRIPTION
## Problem

`agentFiles` treated `CLAUDE.md`, `AGENTS.md`, `.claude` and `.cursor` as one
switch, and put them in the same block as the path ignores. Two bugs came out of
that pairing.

**The agent directory got linted.** `harlanzw()` sets `agentFiles: 'lint'`
whenever the prompt config is on, so the prompt rules can see `CLAUDE.md`. That
also exposed all of `.claude`. Nothing in there is a prompt this repo wrote:

- `.claude/skills` is where skilld installs upstream package docs. Checked every
  tracked `SKILL.md` in og-image, sitemap and nuxt-seo against their
  `skilld-lock.yaml`: all vendored, none authored. The skills you write live in
  `skills/`, and harlan-agent-kit's 22 are all there.
- `.claude/context` is generated design notes and agent job state.
- Agents drop whole repo checkouts in there, which would pull thousands of files
  into the run.

og-image papered over this with a hand-written `{ ignores: ['.claude'] }`.

**`ignores: false` gave it all back.** Sharing one block meant a repo that wanted
to lint its own playground also had to take the agent directory.

## Fix

`.claude` moves to its own always-on `harlanzw/base/agent-ignores` block:

| block | holds | `ignores: false` |
| --- | --- | --- |
| `harlanzw/base/agent-ignores` | `.claude` always; `CLAUDE.md`, `AGENTS.md`, `.cursor` when `agentFiles` is `'ignore'` | unaffected |
| `harlanzw/base/ignores` | `.data`, fixtures, `playground`, `worker-configuration.d.ts`, plus your `ignores` | dropped |

The whole directory goes rather than a list of subdirectories, because what lands
there keeps growing and a denylist has to be chased.

## Evidence

Ran og-image's real config against this build with its hand-written `.claude`
block removed:

- 702 files, matching the current PR
- 0 files under `.claude`
- `CLAUDE.md` still linted

So nuxt-modules/og-image#675 can drop that block.

`pnpm test` 1040 pass, `pnpm typecheck` clean.

## Known limit

A repo that authors `.claude/commands/**` or `.claude/agents/**` loses prompt
linting there. No repo does today. Worth revisiting when one does, since a global
ignore cannot be undone downstream.
