### PR TITLE
fix(ci): test the pull request, not main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,9 @@ on:
       - main
     paths-ignore:
       - '**/README.md'
-  pull_request_target:
+  # `pull_request`, not `pull_request_target`. The latter checks out the base
+  # branch, so every run tested main and no pull request was ever tested.
+  pull_request:
     branches:
       - main
 


### PR DESCRIPTION
## Problem

`test.yml` triggers on `pull_request_target` with a bare `actions/checkout`.
That combination checks out the **base** branch, so every PR run built, linted,
typechecked and tested `main`. No pull request has ever been tested by this
workflow.

Caught by accident: #15 left a scratch file on `main`, and its lint error kept
being reported against a PR whose head had already deleted the file. The run's
`head_sha` pointed at the PR commit while the tree was main's.

## Fix

Switch to `pull_request`, which checks out the merge result, the thing that will
actually land.

Nothing is lost by dropping `pull_request_target`. The job uses no secrets and
declares only `permissions: {contents: read}`. `pull_request_target` exists to
give fork PRs a privileged token, which is a footgun here, not a feature: pairing
it with a checkout of the PR head would run untrusted code with write access.

## Note

`eslint-worker-pool` has the same trigger and the same bare checkout. Handling
that separately.
